### PR TITLE
Fixed dynamic list factory with hidden fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - BUGFIX      #55    Fixed dynamic list factory with hidden fields
  - BUGFIX      #53    Fixed date type default value
  - ENHANCEMENT #24    Update sulu from `alexander-schranz/sulu-form-bundle` from commit `c110e72e44a58a0f53428c153e405124695506f6`
  - BUGFIX      #24    Fixed form preview request analyzer

--- a/Entity/Dynamic.php
+++ b/Entity/Dynamic.php
@@ -14,7 +14,7 @@ class Dynamic implements TimestampableInterface
         self::TYPE_ATTACHMENT,
     ];
 
-    protected static $HIDDEN_TYPES = [
+    public static $HIDDEN_TYPES = [
         'spacer',
         'headline',
         'freeText',


### PR DESCRIPTION
`$HIDDEN_TYPES` is used in `Sulu\Bundle\FormBundle\ListBuilder\DynamicListFactory`