### PR TITLE
Removed unused function "getReceiverTypes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.3.0 (unreleased)
+## 0.3.1
+
+ - HOTFIX      #99    Removed unused function "getReceiverTypes"
+
+## 0.3.0
 
  - BUGFIX      #98    Fixed Dutch translations
  - FEATURE     #83    Refractor static and dynamic form handling for symfony 3 compatibility

--- a/Mail/Helper.php
+++ b/Mail/Helper.php
@@ -131,16 +131,4 @@ class Helper implements HelperInterface
 
         return $this->mailer->send($message);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getReceiverTypes()
-    {
-        return [
-            self::MAIL_RECEIVER_TO => [],
-            self::MAIL_RECEIVER_CC => [],
-            self::MAIL_RECEIVER_BCC => [],
-        ];
-    }
 }

--- a/Mail/HelperInterface.php
+++ b/Mail/HelperInterface.php
@@ -43,11 +43,4 @@ interface HelperInterface
         $ccMail = [],
         $bccMail = []
     );
-
-    /**
-     * Returns an array for holding receivers divided by types.
-     *
-     * @return array
-     */
-    public function getReceiverTypes();
 }

--- a/Mail/NullHelper.php
+++ b/Mail/NullHelper.php
@@ -24,9 +24,8 @@ class NullHelper implements HelperInterface
     /**
      * @param LoggerInterface $logger
      */
-    public function __construct(
-        $logger = null
-    ) {
+    public function __construct($logger = null)
+    {
         $this->logger = $logger ?: new NullLogger();
     }
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade
 
+## 0.3.1
+
+ - `Sulu\Bundle\FormBundle\Mail\HelperInterface::getReceiverTypes` unused function was removed.
+
 ## 0.3.0
 
 ### Symfony 3 compatibility


### PR DESCRIPTION
Without configuration (in the installation process) the `cache:clear` fails with the exception:

```
PHP Fatal error:  Class Sulu\Bundle\FormBundle\Mail\NullHelper contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Sulu\Bundle\FormBundle\Mail\HelperInterface::getReceiverTypes) in /app/vendor/sulu/sulu-form-bundle/Mail/NullHelper.php on line 17
```

see the slack channel https://sulu-io.slack.com/archives/C0430GGCV/p1506653176000156