### PR TITLE
Remove null value

### DIFF
--- a/Configuration/FormConfigurationFactory.php
+++ b/Configuration/FormConfigurationFactory.php
@@ -345,6 +345,10 @@ class FormConfigurationFactory
      */
     private function getEmail($email, $name = null)
     {
+        if (!$email) {
+            return null;
+        }
+
         if (!$name) {
             $name = $email;
         }

--- a/Configuration/FormConfigurationFactory.php
+++ b/Configuration/FormConfigurationFactory.php
@@ -345,10 +345,6 @@ class FormConfigurationFactory
      */
     private function getEmail($email, $name = null)
     {
-        if (!$email || !$name) {
-            return null;
-        }
-
         if (!$name) {
             $name = $email;
         }


### PR DESCRIPTION
If only the email was set, the function always returned "null".