### PR TITLE
Avoid error when structure is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.2
 
+ - HOTFIX     #102    Fixed error when form is loaded without structure in request
  - HOTFIX     #101    Fixed mail receiver for website form
  - HOTFIX     #100    Add mail configuration to documentation
 

--- a/TitleProvider/StructureTitleProvider.php
+++ b/TitleProvider/StructureTitleProvider.php
@@ -50,6 +50,6 @@ class StructureTitleProvider implements TitleProviderInterface
             return;
         }
 
-        return $structure->getProperty('title')->getValue();
+        return $property->getValue();
     }
 }

--- a/TitleProvider/StructureTitleProvider.php
+++ b/TitleProvider/StructureTitleProvider.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\FormBundle\TitleProvider;
 
+use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -38,6 +39,16 @@ class StructureTitleProvider implements TitleProviderInterface
     {
         $request = $this->requestStack->getMasterRequest();
         $structure = $request->attributes->get('structure');
+
+        if (!$structure instanceof StructureInterface || $structure->getUuid() !== $typeId) {
+            return;
+        }
+
+        $property = $structure->getProperty('title');
+
+        if (!$property) {
+            return;
+        }
 
         return $structure->getProperty('title')->getValue();
     }


### PR DESCRIPTION
Fix a problem when a page with a form is loaded over `sulu_content_load` and no `structure` is available on this route.