### PR TITLE
Allow to remove field type by a config definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Tests/app/cache
 Tests/app/logs
 Tests/app/data
 
+/nbproject/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-RC1
 
+ - FEATURE     #129    Add disabled field type configuration
  - BUGFIX      #126    Fixed handle of medias in email template
  - BUGFIX      #125    Fixed attachment for medias in email
  - FEATURE     #124    Fixed date field in list view

--- a/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
@@ -4,16 +4,9 @@ namespace Sulu\Bundle\FormBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
 class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
 {
-    
-    /**
-     * @var string
-     */
-    private $serviceId;
-
     /**
      * @var string
      */
@@ -60,7 +53,6 @@ class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
                     $container->removeDefinition($id);
                 }                
             }
-        };
-
+        }
     }
 }

--- a/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
@@ -56,7 +56,6 @@ class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
             if (isset($attributes[0][$this->aliasAttribute])
                     && in_array($attributes[0][$this->aliasAttribute], $disabledSerivcesAliases)) {
                 if ($container->hasDefinition($id)) {
-                    $container->getDefinition($id)->setTags([]);
                     $container->removeDefinition($id);
                 }
             }

--- a/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
@@ -15,7 +15,7 @@ class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
      * @var string
      */
     private $aliasAttribute;
-    
+
     /**
      * @var string
      */
@@ -42,8 +42,8 @@ class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
         $disabledSerivcesAliases = $container->getParameter($this->disableParam);
         $taggedServices = $container->findTaggedServiceIds($this->tagName);
 
-        foreach ($taggedServices as $id => $attributes) {
-            
+        foreach($taggedServices as $id => $attributes) {
+
             if(isset($attributes[0][$this->aliasAttribute]) 
                     && in_array($attributes[0][$this->aliasAttribute], $disabledSerivcesAliases)) {
                 if ($container->hasDefinition($id)) {

--- a/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
@@ -1,0 +1,66 @@
+<?php
+ 
+namespace Sulu\Bundle\FormBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
+{
+    
+    /**
+     * @var string
+     */
+    private $serviceId;
+
+    /**
+     * @var string
+     */
+    private $tagName;
+
+    /**
+     * @var string
+     */
+    private $aliasAttribute;
+    
+    /**
+     * @var string
+     */
+    private $disableParam;
+    
+    
+    /**
+     * @param string $serviceId
+     * @param string $tagName
+     * @param int $argumentNumber
+     * @param string $aliasAttribute
+     */
+    public function __construct($tagName, $aliasAttribute, $disableParam)
+    {
+        $this->tagName = $tagName;
+        $this->aliasAttribute = $aliasAttribute;
+        $this->disableParam = $disableParam;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $disabledSerivcesAliases = $container->getParameter($this->disableParam);
+        $taggedServices = $container->findTaggedServiceIds($this->tagName);
+
+        foreach ($taggedServices as $id => $attributes) {
+            
+            if(isset($attributes[0][$this->aliasAttribute]) 
+                    && in_array($attributes[0][$this->aliasAttribute],$disabledSerivcesAliases)) {
+                if ($container->hasDefinition($id)) {
+                    $container->getDefinition($id)->setTags([]);
+                    $container->removeDefinition($id);
+                }                
+            }
+        };
+
+    }
+}

--- a/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
@@ -1,5 +1,4 @@
 <?php
- 
 namespace Sulu\Bundle\FormBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -21,8 +20,7 @@ class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
      * @var string
      */
     private $disableParam;
-    
-    
+
     /**
      * @param string $serviceId
      * @param string $tagName
@@ -47,11 +45,11 @@ class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
         foreach ($taggedServices as $id => $attributes) {
             
             if(isset($attributes[0][$this->aliasAttribute]) 
-                    && in_array($attributes[0][$this->aliasAttribute],$disabledSerivcesAliases)) {
+                    && in_array($attributes[0][$this->aliasAttribute], $disabledSerivcesAliases)) {
                 if ($container->hasDefinition($id)) {
                     $container->getDefinition($id)->setTags([]);
                     $container->removeDefinition($id);
-                }                
+                }
             }
         }
     }

--- a/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\FormBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -42,9 +52,8 @@ class RemoveTaggedServiceCollectorCompilerPass implements CompilerPassInterface
         $disabledSerivcesAliases = $container->getParameter($this->disableParam);
         $taggedServices = $container->findTaggedServiceIds($this->tagName);
 
-        foreach($taggedServices as $id => $attributes) {
-
-            if(isset($attributes[0][$this->aliasAttribute]) 
+        foreach ($taggedServices as $id => $attributes) {
+            if (isset($attributes[0][$this->aliasAttribute])
                     && in_array($attributes[0][$this->aliasAttribute], $disabledSerivcesAliases)) {
                 if ($container->hasDefinition($id)) {
                     $container->getDefinition($id)->setTags([]);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -89,6 +89,9 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('ajax_templates')
                 ->prototype('scalar')->end()->defaultValue([])
             ->end()
+            ->arrayNode('dynamic_disabled_types')
+                ->prototype('scalar')->end()->defaultValue([])
+            ->end()
         ;
 
         return $treeBuilder;

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -74,6 +74,7 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_form.dynamic_lists.config', $config['dynamic_lists']);
         $container->setParameter('sulu_form.media_collection_strategy', $config['media_collection_strategy']);
         $container->setParameter('sulu_form.static_forms', $config['static_forms']);
+        $container->setParameter('sulu_form.dynamic_disabled_types', $config['dynamic_disabled_types']);
 
         // Default Media Collection Strategy
         $container->setAlias(

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -140,10 +140,10 @@ sulu_form:
         - street
         - zip
 ```
-Aliases can be found by checking the services definitions:
-- [types.xml](https://github.com/sulu/SuluFormBundle/tree/master/Resources/config/types.xml).
-- [type_mailchimp.xml](https://github.com/sulu/SuluFormBundle/tree/master/Resources/config/type_mailchimp.xml).
-- [type_recaptcha.xml](https://github.com/sulu/SuluFormBundle/tree/master/Resources/config/type_recaptcha.xml).
+Aliases can be found by executing the following command:
+```bash
+php bin/adminconsole debug:container --tag=sulu_form.dynamic.type
+```
 
 ### Implement Form into a custom module:
 

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -126,21 +126,24 @@ sulu_form:
 
 **Now a tab should be visible with a list you can export**
 
-## Disable field type
+## Disable specific field types
 
-To disable fields type available in the form, adding the following lines to the configuration.
-Add the tag aliases of the fields type you want to disable.
-Pay attention to not disable field type already in use in your forms otherwise it will break
+To disable specific field types in dynamic forms, add the following lines to the configuration.
+Use the field type alias to disable it.
+Pay attention to not disable field types already in use in your forms otherwise they will break
 
 ```yml
 sulu_form:
-    dynamic_disable_types:
+    dynamic_disabled_types:
         - firstName
         - lastName
         - street
         - zip
+
 ```
+
 Aliases can be found by running the following command:
+
 ```bash
 php bin/adminconsole debug:container --tag=sulu_form.dynamic.type
 ```

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -140,7 +140,7 @@ sulu_form:
         - street
         - zip
 ```
-Aliases can be found by executing the following command:
+Aliases can be found by running the following command:
 ```bash
 php bin/adminconsole debug:container --tag=sulu_form.dynamic.type
 ```

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -126,6 +126,25 @@ sulu_form:
 
 **Now a tab should be visible with a list you can export**
 
+## Disable field type
+
+To disable fields type available in the form, adding the following lines to the configuration.
+Add the tag aliases of the fields type you want to disable.
+Pay attention to not disable field type already in use in your forms otherwise it will break
+
+```yml
+sulu_form:
+    dynamic_disable_types:
+        - firstName
+        - lastName
+        - street
+        - zip
+```
+Aliases can be found by checking the services definitions:
+- [types.xml](https://github.com/sulu/SuluFormBundle/tree/master/Resources/config/types.xml).
+- [type_mailchimp.xml](https://github.com/sulu/SuluFormBundle/tree/master/Resources/config/type_mailchimp.xml).
+- [type_recaptcha.xml](https://github.com/sulu/SuluFormBundle/tree/master/Resources/config/type_recaptcha.xml).
+
 ### Implement Form into a custom module:
 
  - Implement a Provider for your Module with `TitleProviderInterface`.

--- a/SuluFormBundle.php
+++ b/SuluFormBundle.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\FormBundle;
 
 use Sulu\Bundle\FormBundle\DependencyInjection\CompilerPass\DynamicListBuilderCompilerPass;
 use Sulu\Bundle\FormBundle\DependencyInjection\CompilerPass\ListProviderCompilerPass;
+use Sulu\Bundle\FormBundle\DependencyInjection\CompilerPass\RemoveTaggedServiceCollectorCompilerPass;
 use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -25,6 +26,11 @@ class SuluFormBundle extends Bundle
 
         $container->addCompilerPass(new ListProviderCompilerPass());
         $container->addCompilerPass(new DynamicListBuilderCompilerPass());
+        $container->addCompilerPass(new RemoveTaggedServiceCollectorCompilerPass(
+            'sulu_form.dynamic.type',
+            'alias',
+            'sulu_form.dynamic_disabled_types'
+        ));
         $container->addCompilerPass(new TaggedServiceCollectorCompilerPass(
             'sulu_form.dynamic.form_field_type_pool',
             'sulu_form.dynamic.type',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Allow to remove field type by a config definition

#### Why?

There is a lot of field setted and we don't always need all of them.
This provide a control on which field a user can use.

#### Example Usage

```config.yml

sulu_form:
    dynamic_disabled_types:
        - firstName
        - lastName
        - street
        - zip 
        - city
        - state 
        - function
        - company
        - phone
        - fax
        - country
        - attachment
        - salutation
        - title
```

#### To Do

- [x] Update CHANGELOG.md
- [x] Create documentation

