### PR TITLE
Fix csv export for big results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-RC2
+
+ - BUGFIX      #130    Fixed csv export for big results
+
 ## 1.0.0-RC1
 
  - BUGFIX      #126    Fixed handle of medias in email template

--- a/ListBuilder/DynamicListFactory.php
+++ b/ListBuilder/DynamicListFactory.php
@@ -91,7 +91,9 @@ class DynamicListFactory implements DynamicListFactoryInterface
         $entries = [];
 
         foreach ($dynamics as $dynamic) {
-            $entries = array_merge($entries, $this->getBuilder($builder)->build($dynamic, $locale));
+            foreach ($this->getBuilder($builder)->build($dynamic, $locale) as $entry) {
+                $entries[] = $entry;
+            }
         }
 
         return $entries;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove array_merge from list factory and replace it with a simple array push.

#### Why?

It improve the performance for big results x10.

#### To Do

- [x] Update CHANGELOG.md

