### PR TITLE
Disable csrf token when recaptcha is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## dev-develop
+
+ - ENHANCEMENT #140    Disable csrf token protection when recaptcha field is used
+
 ## 1.0.0-RC2
 
  - BUGFIX      #132    Fix boolean values in list

--- a/Form/Builder.php
+++ b/Form/Builder.php
@@ -232,6 +232,13 @@ class Builder implements BuilderInterface
         $defaults = $this->getDefaults($formEntity, $locale);
         $typeName = $this->titleProviderPool->get($type)->getTitle($typeId);
 
+        $recaptchaFields = $formEntity->getFieldsByType('recaptcha');
+        $csrfTokenProtection = true;
+
+        if (count($recaptchaFields)) {
+            $csrfTokenProtection = false;
+        }
+
         return $this->formFactory->createNamed(
             'dynamic_' . $name . $formEntity->getId(),
             DynamicFormType::class,
@@ -241,6 +248,7 @@ class Builder implements BuilderInterface
                 'locale' => $locale,
                 'type' => $type,
                 'typeId' => $typeId,
+                'csrf_protection' => $csrfTokenProtection,
                 'name' => $name,
                 'block_name' => 'dynamic_' . $name,
             ]


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Disable csrf token when recaptcha field exist.

#### Why?

Active reacaptcha make the csrf token irrelevant.

#### Example Usage

1. Create a form with recaptcha and a form without recaptcha.

#### To Do

- [x] Update CHANGELOG.md

