### PR TITLE
Avoid normalize keys for dynamic widths and ajax templates configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-RC3
 
+ - BUGFIX      #144    Avoid normalize keys for dynamic width and ajax templates configuration
  - BUGFIX      #142    Render placeholder only with value and upate ChoiceTrait
  - BUGFIX      #141    Activate save button on block add
  - ENHANCEMENT #140    Disable csrf token protection when recaptcha field is used

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -73,6 +73,7 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->booleanNode('dynamic_auto_title')->defaultValue(true)->end()
             ->arrayNode('dynamic_widths')
+                ->normalizeKeys(false)
                 ->prototype('scalar')->end()->defaultValue([
                     'full' => 'sulu_form.width.full',
                     'half' => 'sulu_form.width.half',
@@ -87,6 +88,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('dynamic_default_view')->defaultValue('AppBundle:templates:dynamic')->end()
             ->variableNode('dynamic_lists')->defaultValue([])->end()
             ->arrayNode('ajax_templates')
+                ->normalizeKeys(false)
                 ->prototype('scalar')->end()->defaultValue([])
             ->end()
             ->arrayNode('dynamic_disabled_types')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Avoid normalize keys in dynamic widths configuration.

#### Why?

That the key of dynamic widths and ajax templates allow to use dashes.

#### Example Usage

```php
sulu_form:
    dynamic_widths:
        full: sulu_form.width.full
        half: sulu_form.width.half
        one-third: sulu_form.width.one-third
        two-thirds: sulu_form.width.two-thirds
        one-quarter: sulu_form.width.one-quarter
        three-quarters: sulu_form.width.one-sixth
        five-sixths: sulu_form.width.five-sixths
```

#### To Do

- [x] Update CHANGELOG.md

