### PR TITLE
Fix form template structure and move submit label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-RC3
 
+ - BUGFIX      #145    Fix form template structure and move submit label
  - BUGFIX      #144    Avoid normalize keys for dynamic width and ajax templates configuration
  - ENHANCEMENT #143    Remove unused parameter dynamic default view
  - BUGFIX      #142    Render placeholder only with value and upate ChoiceTrait

--- a/Resources/translations/sulu/backend.de.xlf
+++ b/Resources/translations/sulu/backend.de.xlf
@@ -221,7 +221,7 @@
             </trans-unit>
             <trans-unit id="64">
                 <source>sulu_form.submit_label</source>
-                <target>Beschriftung Button Absenden</target>
+                <target>Beschriftung Absende Button</target>
             </trans-unit>
             <trans-unit id="65">
                 <source>sulu_form.success_text</source>

--- a/Resources/translations/sulu/backend.en.xlf
+++ b/Resources/translations/sulu/backend.en.xlf
@@ -221,7 +221,7 @@
             </trans-unit>
             <trans-unit id="64">
                 <source>sulu_form.submit_label</source>
-                <target>Caption Button Submit</target>
+                <target>Caption Submit Button</target>
             </trans-unit>
             <trans-unit id="65">
                 <source>sulu_form.success_text</source>

--- a/Resources/views/forms/template.html.twig
+++ b/Resources/views/forms/template.html.twig
@@ -25,96 +25,90 @@
             </div>
         </div>
     </div>
+
     <div class="fixed-width">
-        <div class="grid">
-            <div class="grid-row m-bottom-40">
+        {#  Section Form Fields #}
+        <div class="grid m-bottom-40">
+            <h2 class="divider m-bottom-20">
+                <%= translate('sulu_form.form_fields') %>
+            </h2>
+
+            {% set blockId = 'fields' %}
+
+            <div class="grid-row m-bottom-0">
                 <div class="grid-col-12">
-                    <div class="grid-col-12 floating m-top-20">
-                        <h2 class="divider m-bottom-20">
-                            <%= translate('sulu_form.form_fields') %>
-                        </h2>
-
-                        {% set blockId = 'fields' %}
-
-                        <div class="grid">
-                            <div id="text-block-header-{{ blockId }}"> {#class="text-blocks-header"#}
-                                <div id="collapse-text-blocks-{{ blockId }}" tabindex="0" class="text-blocks-toggle-btn">
-                                    <%= translate('sulu.content.collapse.blocks') %>
-                                </div>
-                                <div id="expand-text-blocks-{{ blockId }}" tabindex="0" class="text-blocks-toggle-btn">
-                                    <%= translate('sulu.content.expand.blocks') %>
-                                </div>
-                                <div class="clear"></div>
-                            </div>
-
-                            <style>
-                                /* FIXME DropDown to big */
-                                #form-form .grid-row.dropdown-list.dropdown-shadow.husky-select-dropdown-container.top {
-                                    max-height: 160px !important;
-                                    max-height: 70vh !important;
-                                }
-
-                                #form-form .grid-row.dropdown-list.dropdown-shadow.husky-select-dropdown-container {
-                                    height: auto !important;
-                                    max-height: 200px !important;
-                                }
-                            </style>
-
-                            <div class="grid-row small"
-                                 id="{{ blockId }}"
-                                 data-form="true"
-                                 data-type="block"
-                                 data-type-config='
-                                    [
-                                        {% set groupBefore = null %}
-                                        {% for alias, type in types %}
-                                            {% if type.configuration.group != groupBefore and not loop.first %}
-                                            {
-                                                "divider": true
-                                            },{% endif %}
-                                            {
-                                                "data": "{{ alias }}",
-                                                "title": "<%= translate('{{ type.configuration.title }}') %>",
-                                                "tpl": "{{ alias }}-{{ blockId }}-tpl"
-                                            }
-                                            {% if not loop.last %},{% endif %}
-                                            {% set groupBefore = type.configuration.group %}
-                                        {% endfor %}
-                                    ]'
-                                 data-type-min="0"
-                                 data-type-max="999"
-                                 data-type-default="{{ types|keys|first }}"
-                                 data-mapper-property="{{ blockId }}"
-                                 data-mapper-full-class="full"
-                                 data-mapper-empty-class="empty">
-
-                            {% for alias, type in types %}
-                                {% include type.configuration.template with {
-                                'viewData': type.configuration.attributes,
-                                'alias': alias
-                                }%}
-                            {% endfor %}
+                    <div id="text-block-header-{{ blockId }}"> {#class="text-blocks-header"#}
+                        <div id="collapse-text-blocks-{{ blockId }}" tabindex="0" class="text-blocks-toggle-btn">
+                            <%= translate('sulu.content.collapse.blocks') %>
                         </div>
-
-                        <div class="text-block-footer" id="{{ blockId }}-add" style="width: 200px">
-
+                        <div id="expand-text-blocks-{{ blockId }}" tabindex="0" class="text-blocks-toggle-btn">
+                            <%= translate('sulu.content.expand.blocks') %>
                         </div>
+                        <div class="clear"></div>
                     </div>
 
+                    <style>
+                        /* FIXME DropDown to big */
+                        #form-form .grid-row.dropdown-list.dropdown-shadow.husky-select-dropdown-container.top {
+                            max-height: 160px !important;
+                            max-height: 70vh !important;
+                        }
+
+                        #form-form .grid-row.dropdown-list.dropdown-shadow.husky-select-dropdown-container {
+                            height: auto !important;
+                            max-height: 200px !important;
+                        }
+                    </style>
+
+                    <div class="grid-row small"
+                         id="{{ blockId }}"
+                         data-form="true"
+                         data-type="block"
+                         data-type-config='
+                            [
+                                {% set groupBefore = null %}
+                                {% for alias, type in types %}
+                                    {% if type.configuration.group != groupBefore and not loop.first %}
+                                    {
+                                        "divider": true
+                                    },{% endif %}
+                                    {
+                                        "data": "{{ alias }}",
+                                        "title": "<%= translate('{{ type.configuration.title }}') %>",
+                                        "tpl": "{{ alias }}-{{ blockId }}-tpl"
+                                    }
+                                    {% if not loop.last %},{% endif %}
+                                    {% set groupBefore = type.configuration.group %}
+                                {% endfor %}
+                            ]'
+                         data-type-min="0"
+                         data-type-max="999"
+                         data-type-default="{{ types|keys|first }}"
+                         data-mapper-property="{{ blockId }}"
+                         data-mapper-full-class="full"
+                         data-mapper-empty-class="empty">
+
+                        {% for alias, type in types %}
+                            {% include type.configuration.template with {
+                                'viewData': type.configuration.attributes,
+                                'alias': alias
+                            }%}
+                        {% endfor %}
+                    </div>
+
+                    <div class="text-block-footer" id="{{ blockId }}-add" style="width: 200px">
+
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="grid">
-            <h2 class="divider m-bottom-20">
-                <%= translate('sulu_form.website_configuration') %>
-            </h2>
-            <div class="grid-row m-bottom-20">
+
+            <div class="grid-row">
                 <div class="grid-col-12">
                     <div class="form-group">
                         <label for="submitLabel">
                             <%= translate('sulu_form.submit_label') %>
                         </label>
-                        
+
                         <div id="submitLabel"
                              class="form-element husky-validate"
                              data-type="husky-input"
@@ -127,7 +121,15 @@
                     </div>
                 </div>
             </div>
-            <div class="grid-row m-bottom-40">
+        </div>
+
+        {#  Section Website Configuration #}
+        <div class="grid m-bottom-40">
+            <h2 class="divider m-bottom-20">
+                <%= translate('sulu_form.website_configuration') %>
+            </h2>
+
+            <div class="grid-row">
                 <div class="grid-col-12">
                     <div class="form-group">
                         <label for="successText">
@@ -152,9 +154,14 @@
                     </div>
                 </div>
             </div>
+        </div>
+
+        {#  Section E-Mail Configuration #}
+        <div class="grid m-bottom-40">
             <h2 class="divider m-bottom-20">
                 <%= translate('sulu_form.email_configuration') %>
             </h2>
+
             <div class="grid-row m-bottom-20">
                 <div class="grid-col-12">
                     <div class="form-group">
@@ -174,6 +181,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="grid-row m-bottom-20">
                 <div class="grid-col-6">
                     <div class="form-group">
@@ -212,6 +220,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="grid-row m-bottom-20">
                 <div class="grid-col-6">
                     <div class="form-group">
@@ -232,6 +241,7 @@
                         </div>
                     </div>
                 </div>
+
                 <div class="grid-col-6">
                     <div class="form-group">
                         <label for="toName">
@@ -250,6 +260,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="grid-row m-bottom-20">
                 <div class="grid-col-12">
                     <div class="form-group">
@@ -294,6 +305,7 @@
                         </div>
                     </div>
                 </div>
+
                 <div class="grid-col-6">
                     <div class="form-group">
                         <label for="sendAttachments">
@@ -313,6 +325,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="grid-row m-bottom-40">
                 <div class="grid-col-6">
                     <div class="form-group">
@@ -332,6 +345,7 @@
                         </div>
                     </div>
                 </div>
+
                 <div class="grid-col-6">
                     <div class="form-group">
                         <label for="deactivateCustomerMails">
@@ -351,53 +365,51 @@
                     </div>
                 </div>
             </div>
-        </div>
 
-        <!-- Added -->
-        <div class="grid-col-12 floating m-top-20">
             <h2 class="light">
                 <%= translate('sulu_form.receivers') %>
             </h2>
 
-            <div class="grid">
-                <div id="text-block-header-receivers" class="text-blocks-header">
-                    <div id="collapse-text-blocks-receivers" tabindex="0" class="text-blocks-toggle-btn"><%=
-                        translate('sulu.content.collapse.blocks') %>
+            <div class="grid-row m-bottom-0">
+                <div class="grid-col-12">
+                    <div id="text-block-header-receivers" class="text-blocks-header">
+                        <div id="collapse-text-blocks-receivers" tabindex="0" class="text-blocks-toggle-btn"><%=
+                            translate('sulu.content.collapse.blocks') %>
+                        </div>
+                        <div id="expand-text-blocks-receivers" tabindex="0" class="text-blocks-toggle-btn"><%=
+                            translate('sulu.content.expand.blocks') %>
+                        </div>
+                        <div class="clear"></div>
                     </div>
-                    <div id="expand-text-blocks-receivers" tabindex="0" class="text-blocks-toggle-btn"><%=
-                        translate('sulu.content.expand.blocks') %>
+
+                    <div class="grid-row small"
+                         id="receivers"
+                         data-form="true"
+                         data-type="block"
+                         data-type-config='[{"data": "to", "title": "<%= translate('sulu_form.receiver.to') %>", "tpl": "to-receivers-tpl"},{"data": "cc", "title": "<%= translate('sulu_form.receiver.cc') %>", "tpl": "cc-receivers-tpl"},{"data": "bcc", "title": "<%= translate('sulu_form.receiver.bcc') %>", "tpl": "bcc-receivers-tpl"}]'
+                         data-type-min="0"
+                         data-type-max="999"
+                         data-type-default="to"
+                         data-mapper-property="receivers"
+                         data-mapper-full-class="full"
+                         data-mapper-empty-class="empty">
+
+                        {% include 'SuluFormBundle:forms/blocks:email-receiver.html.twig' with {
+                            name: receiverTypes['to']
+                        } %}
+                        {% include 'SuluFormBundle:forms/blocks:email-receiver.html.twig' with {
+                            name: receiverTypes['cc']
+                        } %}
+                        {% include 'SuluFormBundle:forms/blocks:email-receiver.html.twig' with {
+                            name: receiverTypes['bcc']
+                        } %}
                     </div>
-                    <div class="clear"></div>
-                </div>
-                <div class="grid-row small"
-                     id="receivers"
-                     data-form="true"
-                     data-type="block"
-                     data-type-config='[{"data": "to", "title": "<%= translate('sulu_form.receiver.to') %>", "tpl": "to-receivers-tpl"},{"data": "cc", "title": "<%= translate('sulu_form.receiver.cc') %>", "tpl": "cc-receivers-tpl"},{"data": "bcc", "title": "<%= translate('sulu_form.receiver.bcc') %>", "tpl": "bcc-receivers-tpl"}]'
-                     data-type-min="0"
-                     data-type-max="999"
-                     data-type-default="to"
-                     data-mapper-property="receivers"
-                     data-mapper-full-class="full"
-                     data-mapper-empty-class="empty">
 
-                    {% include 'SuluFormBundle:forms/blocks:email-receiver.html.twig' with {
-                        name: receiverTypes['to']
-                    } %}
-                    {% include 'SuluFormBundle:forms/blocks:email-receiver.html.twig' with {
-                        name: receiverTypes['cc']
-                    } %}
-                    {% include 'SuluFormBundle:forms/blocks:email-receiver.html.twig' with {
-                        name: receiverTypes['bcc']
-                    } %}
-                </div>
+                    <div class="text-block-footer" id="receivers-add" style="width: 200px">
 
-                <div class="text-block-footer" id="receivers-add" style="width: 200px">
-
+                    </div>
                 </div>
             </div>
         </div>
-        <!-- Closed -->
-
     </div>
 </form>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Move submit label to form fields configuration and cleanup html structure of form template.

#### Why?

Submit label has more todo with the form as with the website. 
There was an unclosed tag in the first block. 

#### To Do

- [ ] Update CHANGELOG.md

