### PR TITLE
Fix sulu_form_get_by_id twig extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+ - BUGFIX      #146    Fix for sulu_form_get_by_id twig extension.
+
 ## 1.0.0-RC3
 
  - BUGFIX      #145    Fix form template structure and move submit label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
- - BUGFIX      #146    Fix for sulu_form_get_by_id twig extension.
+ - BUGFIX      #146    Fix sulu_form_get_by_id twig extension
 
 ## 1.0.0-RC3
 

--- a/Twig/FormTwigExtension.php
+++ b/Twig/FormTwigExtension.php
@@ -59,8 +59,12 @@ class FormTwigExtension extends \Twig_Extension
      */
     public function getFormById($id, $type, $typeId, $locale = null, $name = 'form')
     {
-        list($formType, $form) = $this->formBuilder->build((int) $id, $type, $typeId, $locale, $name);
+        $form = $this->formBuilder->build((int) $id, $type, $typeId, $locale, $name);
 
+        if (!$form) {
+            return;
+        }
+        
         return $form->createView();
     }
 }

--- a/Twig/FormTwigExtension.php
+++ b/Twig/FormTwigExtension.php
@@ -64,7 +64,7 @@ class FormTwigExtension extends \Twig_Extension
         if (!$form) {
             return;
         }
-        
+
         return $form->createView();
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes no
| Related issues/PRs | no
| License | MIT

#### What's in this PR?

Write the form returned by the formBuilder in a simple variable instead of a php list().
Added early return to prevent a error if the selected form got deleted.

#### Why?

Fixes a bug inside of the FormTwigExtension which results in a symfony error if you try to get a form by id (sulu_form_get_by_id).

#### Example Usage

Use the twig extension as before.

#### To Do

- [x] Update CHANGELOG.md

