### PR TITLE
Fix problems when no translation exist for field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+ - HOTFIX      #161    Fix problems when no translation exist for field
  - BUGFIX      #156    Fix static form handling after refractoring
  - BUGFIX      #150    Fix implement dropzone documentation
  - ENHANCEMENT #147    Improve upgrade errors for 0.2.0 version

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -71,6 +71,11 @@ class DynamicFormType extends AbstractType
 
         foreach ($fields as $key => $field) {
             $fieldTranslation = $field->getTranslation($locale);
+
+            if (!$fieldTranslation) {
+                continue;
+            }
+
             $options = [
                 'constraints' => [],
                 'attr' => [],
@@ -78,20 +83,9 @@ class DynamicFormType extends AbstractType
             ];
 
             // title
-            $title = '';
-            $placeholder = '';
-            $width = 'full';
-
-            // title / placeholder
-            if ($fieldTranslation) {
-                $title = $fieldTranslation->getTitle();
-                $placeholder = $fieldTranslation->getPlaceholder();
-            }
-
-            // width
-            if ($field->getWidth()) {
-                $width = $field->getWidth();
-            }
+            $title = $fieldTranslation->getTitle();
+            $placeholder = $fieldTranslation->getPlaceholder();
+            $width = $field->getWidth() ?: 'full';
 
             $nextField = null;
             $nextWidth = 'full';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix problems when no translation exist for field.

#### Why?

Example attachmentType and other field types which the translation will fail and end in 500 error.

#### BC Breaks/Deprecations

Will not longer render none translated fields until they will be translated.

#### To Do

- [x] Update CHANGELOG.md

# To be discussed

Not sure how we should handle this there are 2 solutions:

## 1. Ignore not translated fields

Ignore the fields until they are translated (currently implemented in this PR)

## 2. Fallback to the default locale

This was the behaviour before but currently not working with attachment


