### PR TITLE
Use branch alias for 2.0 development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
     - php: 7.1
       env:
-        - COMPOSER_FLAGS="--prefer-dist --no-interaction --prefer-lowest"
+        - COMPOSER_FLAGS="--prefer-dist --no-interaction --prefer-lowest --prefer-stable"
     - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "doctrine/orm": "~2.5.3",
         "php": "^7.1",
         "twig/twig": "^1.26 || ^2.0",
-        "sulu/sulu": "dev-develop"
+        "sulu/sulu": "^2.0"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
@@ -50,6 +50,12 @@
     "autoload-dev": {
         "psr-4": {
             "Sulu\\Bundle\\FormBundle\\Tests\\": "Tests"
+        }
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use branch alias for 2.0 development

#### Why?

To allow install sulu form bundle as 2.0@dev requirement.

#### Example Usage

```bash
composer require sulu/sulu-form-bundle:^2.0@dev
```


