### PR TITLE
Fix rendering of checkbox labels that contain links to external or internal pages

### DIFF
--- a/Resources/views/themes/dynamic.html.twig
+++ b/Resources/views/themes/dynamic.html.twig
@@ -103,3 +103,29 @@
         {%- endif -%}
     {%- endfor -%}
 {%- endblock attributes -%}
+
+{# Make sure links also work in labels #}
+{% block checkbox_radio_label -%}
+    {%- if widget is defined -%}
+        {%- if required -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) -%}
+        {%- endif -%}
+        {%- if parent_label_class is defined -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) -%}
+        {%- endif -%}
+        {%- if label is not same as(false) and label is empty -%}
+            {%- if label_format is not empty -%}
+                {%- set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) -%}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
+        {%- endif -%}
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+        {% set label = label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) %}
+        {{- widget|raw }} {{ label|raw -}}
+        </label>
+    {%- endif -%}
+{%- endblock checkbox_radio_label %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

This PR fixes the rendering of checkbox labels that contain links to external or internal pages.

#### Why?

Currently the HTML markup is dumped instead of the link (due to Twig escaping the output).
