### PR TITLE
Added possibility to change mailchimp subscribe status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+ - FEATURE:    #167    Added possibility to change mailchimp subscribe status.
  - FEATURE     #158    Add deletion for dynamic entries
  - BUGFIX      #156    Fix static form handling after refractoring
  - BUGFIX      #150    Fix implement dropzone documentation

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode->children()
             ->scalarNode('mailchimp_api_key')->defaultValue(null)->end()
+            ->scalarNode('mailchimp_subscribe_status')->defaultValue('subscribed')->end()
             ->enumNode('media_collection_strategy')
                 ->values([
                     SuluFormExtension::MEDIA_COLLECTION_STRATEGY_SINGLE,

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -70,6 +70,7 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_form.dynamic_widths', $config['dynamic_widths']);
         $container->setParameter('sulu_form.dynamic_auto_title', $config['dynamic_auto_title']);
         $container->setParameter('sulu_form.mailchimp_api_key', $config['mailchimp_api_key']);
+        $container->setParameter('sulu_form.mailchimp_subscribe_status', $config['mailchimp_subscribe_status']);
         $container->setParameter('sulu_form.dynamic_lists.config', $config['dynamic_lists']);
         $container->setParameter('sulu_form.media_collection_strategy', $config['media_collection_strategy']);
         $container->setParameter('sulu_form.static_forms', $config['static_forms']);

--- a/Event/MailchimpListSubscriber.php
+++ b/Event/MailchimpListSubscriber.php
@@ -24,13 +24,20 @@ class MailchimpListSubscriber implements EventSubscriberInterface
     protected $apiKey;
 
     /**
+     * @var string
+     */
+    protected $subscribeStatus;
+
+    /**
      * MailchimpListSubscriber constructor.
      *
      * @param string $apiKey
+     * @param string $subscribeStatus
      */
-    public function __construct($apiKey = '')
+    public function __construct($apiKey = '', $subscribeStatus = 'subscribed')
     {
         $this->apiKey = $apiKey;
+        $this->subscribeStatus = $subscribeStatus;
     }
 
     /**
@@ -82,7 +89,7 @@ class MailchimpListSubscriber implements EventSubscriberInterface
 
                 $MailChimp->post('lists/' . $listId . '/members', [
                     'email_address' => $email,
-                    'status' => 'subscribed',
+                    'status' => $this->subscribeStatus,
                 ]);
 
                 if ('' == $fname && '' == $lname) {

--- a/Resources/config/type_mailchimp.xml
+++ b/Resources/config/type_mailchimp.xml
@@ -6,6 +6,7 @@
     <services>
         <service id="sulu_form.subscriber.mailchimp_list_subscriber" class="Sulu\Bundle\FormBundle\Event\MailchimpListSubscriber">
             <argument>%sulu_form.mailchimp_api_key%</argument>
+            <argument>%sulu_form.mailchimp_subscribe_status%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/Resources/doc/mailchimp.md
+++ b/Resources/doc/mailchimp.md
@@ -27,22 +27,17 @@ add the following config to `app/config/config.yml`
 ```yml
 sulu_form:
     mailchimp_api_key: %parameter_recommended_for_mailchimp_api_key%
-    mailchimp_subscribe_status: %parameter_recommended_for_mailchimp_subscribe_status%
 ```
 
 ## Subscribe Status
 
-- subscribed
-    - ```This address is on the list and ready to receive email. You can only send campaigns to ‘subscribed’ addresses.```
-    
-- unsibscribed
-    - ```This address used to be on the list but isn’t anymore.```
+To change the subscribe status from `subscribed` to `pending` you need to configure the following:
 
-- pending 
-    - ```This address requested to be added with double-opt-in but hasn’t confirmed their subscription yet.```
-    
-- cleaned
-    - ```This address bounced and has been removed from the list.```
+```yml
+sulu_form:
+    mailchimp_subscribe_status: "pending"
+```
+https://developer.mailchimp.com/documentation/mailchimp/guides/manage-subscribers-with-the-mailchimp-api/#check-subscription-status
 
 ## Where is my Mailchimp API Key?
 Account -> Extras -> Api Keys (create new / use existing)

--- a/Resources/doc/mailchimp.md
+++ b/Resources/doc/mailchimp.md
@@ -9,7 +9,7 @@ First of all you need to install drewn's Mailchimp API, if this bundle is missin
 ```json
 {
     "require": {
-        "drewm/mailchimp-api": "^2.5"
+        "drewm/mailchimp-api": "^2.2"
     }
 }
 ```
@@ -17,7 +17,7 @@ First of all you need to install drewn's Mailchimp API, if this bundle is missin
 or
 
 ```bash
-composer require drewm/mailchimp-api:^2.5
+composer require drewm/mailchimp-api:^2.2
 ```
 
 ## Config

--- a/Resources/doc/mailchimp.md
+++ b/Resources/doc/mailchimp.md
@@ -9,7 +9,7 @@ First of all you need to install drewn's Mailchimp API, if this bundle is missin
 ```json
 {
     "require": {
-        "drewm/mailchimp-api": "^2.2"
+        "drewm/mailchimp-api": "^2.5"
     }
 }
 ```
@@ -17,7 +17,7 @@ First of all you need to install drewn's Mailchimp API, if this bundle is missin
 or
 
 ```bash
-composer require drewm/mailchimp-api:^2.2
+composer require drewm/mailchimp-api:^2.5
 ```
 
 ## Config
@@ -27,7 +27,12 @@ add the following config to `app/config/config.yml`
 ```yml
 sulu_form:
     mailchimp_api_key: %parameter_recommended_for_mailchimp_api_key%
+    mailchimp_subscribe_status: %parameter_recommended_for_mailchimp_subscribe_status%
 ```
+
+## Subscribe Status
+
+Short explanation ... pending, subscribed.
 
 ## Where is my Mailchimp API Key?
 Account -> Extras -> Api Keys (create new / use existing)

--- a/Resources/doc/mailchimp.md
+++ b/Resources/doc/mailchimp.md
@@ -32,7 +32,17 @@ sulu_form:
 
 ## Subscribe Status
 
-Short explanation ... pending, subscribed.
+- subscribed
+    - ```This address is on the list and ready to receive email. You can only send campaigns to ‘subscribed’ addresses.```
+    
+- unsibscribed
+    - ```This address used to be on the list but isn’t anymore.```
+
+- pending 
+    - ```This address requested to be added with double-opt-in but hasn’t confirmed their subscription yet.```
+    
+- cleaned
+    - ```This address bounced and has been removed from the list.```
 
 ## Where is my Mailchimp API Key?
 Account -> Extras -> Api Keys (create new / use existing)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added new configuration to change the subsribe status of mailchimp.

#### Why?

To add the possibility to change the default (`subsribed`) to (`pending`), which is needed in some projects.

#### Example Usage

```config.yml
sulu_form:
      mailchimp_subscribe_status: "%parameter_recommended_for_mailchimp_subscribe_status%"
```

#### BC Breaks/Deprecations

None

#### To Do

- [x] Update CHANGELOG.md
- [x] Create documentation

