### PR TITLE
Added formdata parameter to getNotifySubject function in FormConfigurationFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+ - FEATURE:    #172    Added formdata parameter to getNotifySubject function in FormConfigurationFactory
  - FEATURE:    #167    Added possibility to change mailchimp subscribe status
 
 ## 1.0.0-RC4

--- a/Configuration/FormConfigurationFactory.php
+++ b/Configuration/FormConfigurationFactory.php
@@ -129,7 +129,7 @@ class FormConfigurationFactory
 
         $adminMailConfiguration = $this->createMailConfiguration($locale);
 
-        $adminMailConfiguration->setSubject($type->getNotifySubject());
+        $adminMailConfiguration->setSubject($type->getNotifySubject($formData));
         $adminMailConfiguration->setFrom($type->getNotifyFromMailAddress($formData));
         $adminMailConfiguration->setTo($type->getNotifyToMailAddress($formData));
         $adminMailConfiguration->setReplyTo($type->getNotifyReplyToMailAddress($formData));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added formData parameter to getNotifySubject function in FormConfigurationFactory.

#### Why?

Because we want to get content from the formData in the getNotifySubject function.
