### PR TITLE
Fixed missing `sulu_form.navigation_provider.template` service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## unreleased
 
- - FEATURE:    #172    Added formdata parameter to getNotifySubject function in FormConfigurationFactory
- - FEATURE:    #167    Added possibility to change mailchimp subscribe status
+ - BUGFIX      #173    Fixed missing `sulu_form.navigation_provider.template` service
+ - FEATURE     #172    Added formdata parameter to getNotifySubject function in FormConfigurationFactory
+ - FEATURE     #167    Added possibility to change mailchimp subscribe status
 
 ## 1.0.0-RC4
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -43,6 +43,14 @@
             <tag name="sulu.context" context="admin" />
         </service>
 
+        <!-- Static -->
+        <service id="sulu_form.navigation_provider.template"
+                 class="Sulu\Bundle\FormBundle\Admin\TemplateNavigationProvider">
+            <argument type="service" id="sulu.list.provider.registry"/>
+
+            <tag name="sulu_admin.content_navigation" alias="content" />
+        </service>
+
         <!-- List Provider Registry -->
         <service id="sulu.list.provider.registry"
                  class="Sulu\Bundle\FormBundle\Provider\ListProviderRegistry" />
@@ -144,7 +152,7 @@
             <argument type="collection"/>
         </service>
 
-        <!-- TWIG extension -->
+        <!-- Twig extension -->
         <service id="sulu_form.twig_extension" class="Sulu\Bundle\FormBundle\Twig\FormTwigExtension">
             <tag name="twig.extension"/>
             <argument type="service" id="sulu_form.builder"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #168
| License | MIT

#### What's in this PR?

Add missing navigation provider service for static templates.

#### Why?

Service did get lost a long time ago 🤔 
