### PR TITLE
Fixed Grammar in Documentation of static forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.0-RC6
-
+ - BUGFIX      #184    Added fixes for Grammar of static form documentation
  - FEATURE     #183    Add tests running on php 7.3
  - BUGFIX      #182    Fix compatibility with doctrine/orm ^2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 1.0.0-RC6
- - BUGFIX      #184    Added fixes for Grammar of static form documentation
+
+ - BUGFIX      #184    Add fixes for Grammar of static form documentation
  - FEATURE     #183    Add tests running on php 7.3
  - BUGFIX      #182    Fix compatibility with doctrine/orm ^2.6
 

--- a/Resources/doc/static.md
+++ b/Resources/doc/static.md
@@ -127,8 +127,8 @@ In your Bundle under `Resources/config/doctrine/` create your `*.orm.xml` file:
 </doctrine-mapping>
 ```
 
-Create the entity with `app/console doctrine:generate:entities ClientWebsiteBundle`  
-Sulu have sometimes problem with this command and you maybe need first create the empty class in your `Entity` Folder. (Issue: https://github.com/sulu-io/sulu/issues/1343) 
+Create the entity with `app/console doctrine:generate:entities ClientWebsiteBundle`.
+Sometimes Sulu has problems with this command, in this case you will need to create an empty class in your `Entity` Folder. (Issue: https://github.com/sulu-io/sulu/issues/1343) 
 
 ## Create Form Type
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

As title suggests. There has been bad Grammar in the documentation.

#### Why?

Documentation Grammar.