### PR TITLE
Increase mailchimp limit from 10 to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-RC6
 
+ - ENHANCEMENT #186    Increase mailchimp list limit from 10 to 100
+ - BUGFIX      #185    Fix hidding of untranslated forms and form fields
  - BUGFIX      #184    Add fixes for Grammar of static form documentation
  - FEATURE     #183    Add tests running on php 7.3
  - BUGFIX      #182    Fix compatibility with doctrine/orm ^2.6

--- a/Dynamic/Types/MailchimpType.php
+++ b/Dynamic/Types/MailchimpType.php
@@ -80,7 +80,7 @@ class MailchimpType implements FormFieldTypeInterface
         }
 
         $mailChimp = new \DrewM\MailChimp\MailChimp($this->apiKey);
-        $response = $mailChimp->get('lists');
+        $response = $mailChimp->get('lists', ['count' => 100]);
 
         if (!isset($response['lists'])) {
             return $lists;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #176
| License | MIT

#### What's in this PR?

Increase mailchimp limit from 10 to 100.

#### Why?

Sometimes there are more than 10 lists in mailchimp.

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [x] Update CHANGELOG.md
