### PR TITLE
Fix travis mysql service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
   global:
     - SYMFONY__DATABASE__VERSION=5.5.39
 
+services:
+    - mysql
+
 matrix:
   include:
     - php: 5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## dev-master
+
+ - BUGFIX      #189    Fix travis mysql service
+
 ## 1.0.0-RC6
 
  - ENHANCEMENT #186    Increase mailchimp list limit from 10 to 100


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Start the mysql service manually.

#### Why?

Service not longer started automatically: See https://docs.travis-ci.com/user/reference/xenial/#services-disabled-by-default

#### To Do

- [x] Update CHANGELOG.md