### PR TITLE
Use nested json properties in form field blocks

### DIFF
--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -383,10 +383,7 @@ class FormController extends FOSRestController implements ClassResourceInterface
                 $fieldData['placeholder'] = $fieldTranslation->getPlaceholder();
                 $fieldData['defaultValue'] = $fieldTranslation->getDefaultValue();
                 $fieldData['shortTitle'] = $fieldTranslation->getShortTitle();
-
-                foreach ($fieldTranslation->getOptions() as $key => $option) {
-                    $fieldData['options[' . $key . ']'] = $option;
-                }
+                $fieldData['options'] = $fieldTranslation->getOptions();
             }
 
             $fields[] = $fieldData;

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -242,22 +242,7 @@ class FormManager
             $fieldTranslation->setPlaceholder(self::getValue($fieldData, 'placeholder'));
             $fieldTranslation->setDefaultValue(self::getValue($fieldData, 'defaultValue'));
             $fieldTranslation->setShortTitle(self::getValue($fieldData, 'shortTitle'));
-
-            // Field Options
-            $prefix = 'options[';
-
-            $keys = array_filter(array_keys($fieldData), function ($key) use ($prefix) {
-                return 0 === strpos($key, $prefix);
-            });
-
-            $options = array_intersect_key($fieldData, array_flip($keys));
-
-            foreach ($options as $key => $value) {
-                unset($options[$key]);
-                $options[trim(substr($key, strlen($prefix)), ']')] = $value;
-            }
-
-            $fieldTranslation->setOptions($options);
+            $fieldTranslation->setOptions(self::getValue($fieldData, 'options'));
 
             // Add Translation to Field
             if (!$fieldTranslation->getId()) {

--- a/Resources/config/form-fields/default_field_extended.xml
+++ b/Resources/config/form-fields/default_field_extended.xml
@@ -14,7 +14,7 @@
             <title>sulu_form.default</title>
         </meta>
     </property>
-    <property name="options[choices]" type="text_area">
+    <property name="options/choices" type="text_area">
         <meta>
             <title>sulu_form.choice</title>
         </meta>

--- a/Resources/config/form-fields/field_attachment.xml
+++ b/Resources/config/form-fields/field_attachment.xml
@@ -4,7 +4,7 @@
             xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
     <xi:include href="default_field.xml"  xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
                       xpointer(//sulu:property)"/>
-    <property name="options[type]" type="select" colspan="6">
+    <property name="options/type" type="select" colspan="6">
         <meta>
             <title>sulu_form.attachment_restrict</title>
             <info_text>sulu_form.attachment_restrict.hint</info_text>
@@ -29,7 +29,7 @@
             </param>
         </params>
     </property>
-    <property name="options[max]" type="number" colspan="6">
+    <property name="options/max" type="number" colspan="6">
         <meta>
             <title>sulu_form.attachment_max</title>
         </meta>

--- a/Resources/config/form-fields/field_choices.xml
+++ b/Resources/config/form-fields/field_choices.xml
@@ -4,7 +4,7 @@
             xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
     <xi:include href="default_field.xml"  xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
                       xpointer(//sulu:property)"/>
-    <property name="options[choices]" type="text_area">
+    <property name="options/choices" type="text_area">
         <meta>
             <title>sulu_form.choice</title>
         </meta>

--- a/Resources/config/form-fields/field_date.xml
+++ b/Resources/config/form-fields/field_date.xml
@@ -14,7 +14,7 @@
             <title>sulu_form.default</title>
         </meta>
     </property>
-    <property name="options[birthday]" type="checkbox" colspan="1">
+    <property name="options/birthday" type="checkbox" colspan="1">
         <meta>
             <title>sulu_form.birthday</title>
         </meta>
@@ -22,5 +22,4 @@
             <param name="type" value="toggler"/>
         </params>
     </property>
-
 </properties>

--- a/Resources/config/form-fields/field_mailchimp.xml
+++ b/Resources/config/form-fields/field_mailchimp.xml
@@ -4,7 +4,7 @@
             xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
     <xi:include href="default_field.xml"  xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
                       xpointer(//sulu:property)"/>
-    <property name="options[listId]" type="single_select">
+    <property name="options/listId" type="single_select">
         <meta>
             <title>sulu_form.mailchimp_list</title>
         </meta>

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -233,7 +233,8 @@ class FormControllerTest extends SuluTestCase
             $this->assertEquals('Short Title', $response['fields'][$key]['shortTitle']);
             $this->assertEquals('Placeholder', $response['fields'][$key]['placeholder']);
             $this->assertEquals('Default Value', $response['fields'][$key]['defaultValue']);
-            $this->assertCountFields(10, $response['fields'][$key]);
+            $this->assertNotNull($response['fields'][$key]['options']);
+            $this->assertCountFields(11, $response['fields'][$key]);
         }
         // Receivers
         $this->assertCount(3, $response['receivers']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | https://github.com/sulu/sulu/pull/4636
| License | MIT

#### What's in this PR?

This PR uses nested json properties in the xml files for the form field blocks. In order to work the PR https://github.com/sulu/sulu/pull/4636 has to be merged previously into the Sulu Core.

#### Why?

Instead of 
```xml
 <property name="options[choices]" type="text_area"/>
```
the nested properties are accessed in the following way
```xml
 <property name="options/choices" type="text_area"/>
```
This allows to simplify the logic of retrieving and storing of options in the FormController and FormManager.

#### To Do

- [ ] Update CHANGELOG.md
- [ ] Create documentation

