### PR TITLE
Fix travis ci build for php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix travis ci for php 5.5.

#### Why?

Travis seems not support php 5.5 on there new dist. See https://travis-ci.org/sulu/SuluFormBundle/jobs/564920930