### PR TITLE
Mailchimp List Select 

### DIFF
--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -161,6 +161,12 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         $loader->load('title-providers.xml');
 
         if ($config['mailchimp_api_key']) {
+            if (!class_exists(\DrewM\MailChimp\MailChimp::class) ) {
+                throw new \LogicException(
+                    'You need to install the "drewm/mailchimp-api" package to use the mailchimp type.'
+                );
+            }
+
             $loader->load('type_mailchimp.xml');
         }
 

--- a/Dynamic/FormFieldTypeConfiguration.php
+++ b/Dynamic/FormFieldTypeConfiguration.php
@@ -44,11 +44,10 @@ class FormFieldTypeConfiguration
      * @param array $attributes
      * @param string $group
      */
-    public function __construct($titleTranslationKey, $xmlPath, $attributes = [], $group = '')
+    public function __construct($titleTranslationKey, $xmlPath, $group = '')
     {
         $this->title = $titleTranslationKey;
         $this->xmlPath = $xmlPath;
-        $this->attributes = $attributes;
         $this->group = $group;
     }
 
@@ -96,30 +95,6 @@ class FormFieldTypeConfiguration
     public function setXmlPath($xmlPath)
     {
         $this->xmlPath = $xmlPath;
-
-        return $this;
-    }
-
-    /**
-     * Returns attributes.
-     *
-     * @return array
-     */
-    public function getAttributes()
-    {
-        return $this->attributes;
-    }
-
-    /**
-     * Sets attributes.
-     *
-     * @param array $attributes
-     *
-     * @return FormFieldTypeConfiguration
-     */
-    public function setAttributes($attributes)
-    {
-        $this->attributes = $attributes;
 
         return $this;
     }

--- a/Dynamic/FormFieldTypeConfiguration.php
+++ b/Dynamic/FormFieldTypeConfiguration.php
@@ -27,11 +27,6 @@ class FormFieldTypeConfiguration
     private $xmlPath;
 
     /**
-     * @var array
-     */
-    private $attributes = [];
-
-    /**
      * @var string
      */
     private $group;
@@ -41,7 +36,6 @@ class FormFieldTypeConfiguration
      *
      * @param string $titleTranslationKey
      * @param string $xmlPath
-     * @param array $attributes
      * @param string $group
      */
     public function __construct($titleTranslationKey, $xmlPath, $group = '')

--- a/Dynamic/Helper/MailchimpListSelect.php
+++ b/Dynamic/Helper/MailchimpListSelect.php
@@ -33,8 +33,7 @@ class MailchimpListSelect
     {
         $lists = [];
 
-        // If Milchimp class doesn't exist or no key is set return empty list.
-        if (!class_exists(\DrewM\MailChimp\MailChimp::class) || !$this->apiKey) {
+        if (!$this->apiKey) {
             return $lists;
         }
 

--- a/Dynamic/Helper/MailchimpListSelect.php
+++ b/Dynamic/Helper/MailchimpListSelect.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Dynamic\Helper;
+
+class MailchimpListSelect
+{
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @param string $apiKey
+     */
+    public function __construct($apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * Returns array of Mailchimp lists of given account defined by the API key.
+     */
+    public function getValues(): array
+    {
+        $lists = [];
+
+        // If Milchimp class doesn't exist or no key is set return empty list.
+        if (!class_exists(\DrewM\MailChimp\MailChimp::class) || !$this->apiKey) {
+            return $lists;
+        }
+
+        $mailChimp = new \DrewM\MailChimp\MailChimp($this->apiKey);
+        $response = $mailChimp->get('lists', ['count' => 100]);
+
+        if (!isset($response['lists'])) {
+            return $lists;
+        }
+
+        foreach ($response['lists'] as $list) {
+            $lists[] = [
+                'name' => $list['id'],
+                'title' => $list['name'],
+            ];
+        }
+
+        return $lists;
+    }
+}

--- a/Dynamic/Types/AttachmentType.php
+++ b/Dynamic/Types/AttachmentType.php
@@ -37,7 +37,6 @@ class AttachmentType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.attachment',
             __DIR__ . '/../../Resources/config/form-fields/field_attachment.xml',
-            [],
             'special'
         );
     }

--- a/Dynamic/Types/CheckboxMultipleType.php
+++ b/Dynamic/Types/CheckboxMultipleType.php
@@ -32,7 +32,6 @@ class CheckboxMultipleType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.checkboxmultiple',
             __DIR__ . '/../../Resources/config/form-fields/field_choices.xml',
-            [],
             'complex'
         );
     }

--- a/Dynamic/Types/CheckboxType.php
+++ b/Dynamic/Types/CheckboxType.php
@@ -32,7 +32,6 @@ class CheckboxType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.checkbox',
             __DIR__ . '/../../Resources/config/form-fields/default_field.xml',
-            [],
             'complex'
         );
     }

--- a/Dynamic/Types/DateType.php
+++ b/Dynamic/Types/DateType.php
@@ -31,7 +31,6 @@ class DateType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.date',
             __DIR__ . '/../../Resources/config/form-fields/field_date.xml',
-            [],
             'basic'
         );
     }

--- a/Dynamic/Types/DropdownMultiple.php
+++ b/Dynamic/Types/DropdownMultiple.php
@@ -32,7 +32,6 @@ class DropdownMultiple implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.dropdownmultiple',
             __DIR__ . '/../../Resources/config/form-fields/default_field_extended.xml',
-            [],
             'complex'
         );
     }

--- a/Dynamic/Types/DropdownType.php
+++ b/Dynamic/Types/DropdownType.php
@@ -33,7 +33,6 @@ class DropdownType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.dropdown',
             __DIR__ . '/../../Resources/config/form-fields/default_field_extended.xml',
-            [],
             'complex'
         );
     }

--- a/Dynamic/Types/FreeTextType.php
+++ b/Dynamic/Types/FreeTextType.php
@@ -32,7 +32,6 @@ class FreeTextType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.freetext',
             __DIR__ . '/../../Resources/config/form-fields/field_title.xml',
-            [],
             'additional'
         );
     }

--- a/Dynamic/Types/HeadlineType.php
+++ b/Dynamic/Types/HeadlineType.php
@@ -32,7 +32,6 @@ class HeadlineType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.headline',
             __DIR__ . '/../../Resources/config/form-fields/field_title.xml',
-            [],
             'additional'
         );
     }

--- a/Dynamic/Types/MailchimpType.php
+++ b/Dynamic/Types/MailchimpType.php
@@ -23,19 +23,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 class MailchimpType implements FormFieldTypeInterface
 {
     /**
-     * @var string
-     */
-    private $apiKey;
-
-    /**
-     * @param string $apiKey
-     */
-    public function __construct($apiKey)
-    {
-        $this->apiKey = $apiKey;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getConfiguration()
@@ -43,7 +30,6 @@ class MailchimpType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.mailchimp',
             __DIR__ . '/../../Resources/config/form-fields/field_mailchimp.xml',
-            ['mailChimpLists' => $this->getMailChimpLists()],
             'special'
         );
     }
@@ -63,36 +49,5 @@ class MailchimpType implements FormFieldTypeInterface
     public function getDefaultValue(FormField $field, $locale)
     {
         return $field->getTranslation($locale)->getDefaultValue();
-    }
-
-    /**
-     * Returns array of Mailchimp lists of given account defined by the API key.
-     *
-     * @return array
-     */
-    private function getMailChimpLists()
-    {
-        $lists = [];
-
-        // If Milchimp class doesn't exist or no key is set return empty list.
-        if (!class_exists(\DrewM\MailChimp\MailChimp::class) || !$this->apiKey) {
-            return $lists;
-        }
-
-        $mailChimp = new \DrewM\MailChimp\MailChimp($this->apiKey);
-        $response = $mailChimp->get('lists', ['count' => 100]);
-
-        if (!isset($response['lists'])) {
-            return $lists;
-        }
-
-        foreach ($response['lists'] as $list) {
-            $lists[] = [
-                'id' => $list['id'],
-                'name' => $list['name'],
-            ];
-        }
-
-        return $lists;
     }
 }

--- a/Dynamic/Types/RadioButtonsType.php
+++ b/Dynamic/Types/RadioButtonsType.php
@@ -33,7 +33,6 @@ class RadioButtonsType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.radiobuttons',
             __DIR__ . '/../../Resources/config/form-fields/field_choices.xml',
-            [],
             'complex'
         );
     }

--- a/Dynamic/Types/RecaptchaType.php
+++ b/Dynamic/Types/RecaptchaType.php
@@ -31,7 +31,6 @@ class RecaptchaType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.recaptcha',
             __DIR__ . '/../../Resources/config/form-fields/default_field.xml',
-            [],
             'special'
         );
     }

--- a/Dynamic/Types/SpacerType.php
+++ b/Dynamic/Types/SpacerType.php
@@ -32,7 +32,6 @@ class SpacerType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.spacer',
             __DIR__ . '/../../Resources/config/form-fields/header_without_required.xml',
-            [],
             'additional'
         );
     }

--- a/Dynamic/Types/TextType.php
+++ b/Dynamic/Types/TextType.php
@@ -32,7 +32,6 @@ class TextType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.text',
             __DIR__ . '/../../Resources/config/form-fields/field_example_default.xml',
-            [],
             'basic'
         );
     }

--- a/Dynamic/Types/TextareaType.php
+++ b/Dynamic/Types/TextareaType.php
@@ -32,7 +32,6 @@ class TextareaType implements FormFieldTypeInterface
         return new FormFieldTypeConfiguration(
             'sulu_form.type.textarea',
             __DIR__ . '/../../Resources/config/form-fields/field_example_default.xml',
-            [],
             'basic'
         );
     }

--- a/Resources/config/form-fields/field_mailchimp.xml
+++ b/Resources/config/form-fields/field_mailchimp.xml
@@ -4,28 +4,16 @@
             xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/properties-1.0.xsd">
     <xi:include href="default_field.xml"  xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
                       xpointer(//sulu:property)"/>
-    <property name="options/listId" type="single_select">
+    <property name="options/listId" type="single_select" mandatory="true">
         <meta>
             <title>sulu_form.mailchimp_list</title>
         </meta>
         <params>
-            <param name="values" type="collection">
-                <param name="id1">
-                    <meta>
-                        <title>sulu_form.mailchimp.list</title>
-                    </meta>
-                </param>
-                <param name="id2">
-                    <meta>
-                        <title>sulu_form.mailchimp.list</title>
-                    </meta>
-                </param>
-                <param name="id3">
-                    <meta>
-                        <title>sulu_form.mailchimp.list</title>
-                    </meta>
-                </param>
-            </param>
+            <param
+                    name="values"
+                    type="expression"
+                    value="service('sulu_form.dynamic.mailchimp_list_select').getValues()"
+            />
         </params>
     </property>
 </properties>

--- a/Resources/config/type_mailchimp.xml
+++ b/Resources/config/type_mailchimp.xml
@@ -11,8 +11,11 @@
         </service>
 
         <service id="sulu_form.dynamic.type_mailchimp" class="Sulu\Bundle\FormBundle\Dynamic\Types\MailchimpType">
-            <argument>%sulu_form.mailchimp_api_key%</argument>
             <tag name="sulu_form.dynamic.type" alias="mailchimp"/>
+        </service>
+
+        <service id="sulu_form.dynamic.mailchimp_list_select" class="Sulu\Bundle\FormBundle\Dynamic\Helper\MailchimpListSelect" public="true">
+            <argument>%sulu_form.mailchimp_api_key%</argument>
         </service>
     </services>
 </container>

--- a/Resources/doc/mailchimp.md
+++ b/Resources/doc/mailchimp.md
@@ -26,8 +26,10 @@ Add the following config to `config/packages/sulu_form.yaml`:
 
 ```yml
 sulu_form:
-    mailchimp_api_key: %parameter_recommended_for_mailchimp_api_key%
+    mailchimp_api_key: "<YOUR_API_KEY>"
 ```
+
+It is recommended to store the api key as environment variable see [Symfony Docs](https://symfony.com/doc/4.4/configuration.html#configuration-environments).
 
 ## Subscribe Status
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT

#### What's in this PR?

This PR adds a `MailchimpListSelect` helper class which is used in the `field_mailchimp.xml` to load the mailchimp lists and display them in a single select field. The mailchimp lists are loaded in the helper class in the same way as previously in the `MailchimpType` class.

Furthermore the property `attributes` is removed in the `FormFieldTypeConfiguration` because it is not used anymore by any dynamic type.

The changes in this PR are not properly tested yet.

#### Why?

The `field_mailchimp.xml` needs to load the mailchimp lists dynamically for a given account defined by the API key.

#### Example Usage

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Update CHANGELOG.md
- [x] Create documentation

