### PR TITLE
Ensure compatibility with MySQL 8 ("function" is a reserved keyword there)

### DIFF
--- a/Resources/config/doctrine/Dynamic.orm.xml
+++ b/Resources/config/doctrine/Dynamic.orm.xml
@@ -27,7 +27,7 @@
         <field name="city" column="city" type="string" nullable="true"/>
         <field name="state" column="state" type="string" nullable="true"/>
         <field name="country" column="country" type="string" length="2" nullable="true"/>
-        <field name="function" column="function" type="string" nullable="true"/>
+        <field name="function" column="`function`" type="string" nullable="true"/>
         <field name="company" column="company" type="text" nullable="true"/>
         <field name="text" column="text" type="string" nullable="true"/>
         <field name="textarea" column="textarea" type="text" nullable="true"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | n/a
| Related issues/PRs | n/a
| License | MIT

#### What's in this PR?

A small change in the ORM definition file for `Sulu\Bundle\FormBundle\Entity\Dynamic` to make database queries compatible with MySQL 8+. A few [keywords were reserved](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-F) with the release of the new version of MySQL.

#### Why?

With MySQL 8 as RDBMS, the following error currently occurs when a `Dynamic` object is persisted:

    PDOException  PDOException  SyntaxErrorException
    HTTP 500 Internal Server Error
    An exception occurred while executing 'INSERT INTO fo_dynamics (type, typeId, locale, webspaceKey, typeName, salutation, title, firstName, lastName, email, phone, fax, street, zip, city, state, country, function, company, text, textarea, date, attachment, checkbox, checkboxMultiple, dropdown, dropdownMultiple, radioButtons, data, created, changed, formId, idUsersCreator, idUsersChanger) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [redacted]:
    SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; 
    check the manual that corresponds to your MySQL server version for the right syntax to use
    near 'function, company, text, textarea, date, attachment, checkbox, checkboxMultiple,' at line 1

#### Example Usage

?

#### BC Breaks/Deprecations

None as the field name is escaped in accordance with MySQL 5.x

#### To Do

nothing

