### PR TITLE
Add striptags to email labels

### DIFF
--- a/Resources/views/mails/notify.html.twig
+++ b/Resources/views/mails/notify.html.twig
@@ -20,6 +20,6 @@
     {% endif %}
 
     {% if value is not empty %}
-        <strong>{{ field.shortTitle|default(field.title)|raw }}</strong>: {{ value }}<br>
+        <strong>{{ field.shortTitle|default(field.title)|striptags|raw }}</strong>: {{ value }}<br>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR add the filter `striptags` to notify email labels.