### PR TITLE
Fix line breaks in notify emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## dev-master
+
+ - BUGFIX      #215    Fix line breaks in notify emails
+
 ## 1.0.1
 
  - BUGFIX      #201    Fix configuration of plain text emails   

--- a/Resources/views/mails/notify.html.twig
+++ b/Resources/views/mails/notify.html.twig
@@ -17,9 +17,13 @@
         {% endif %}
     {% elseif value.timestamp is defined %}
         {% set value = value|date('d.m.Y') %}
+    {% else %}
+        {% set value %}
+            {{- value|nl2br -}}
+        {% endset %}
     {% endif %}
 
     {% if value is not empty %}
-        <strong>{{ field.shortTitle|default(field.title)|raw }}</strong>: {{ value|nl2br }}<br>
+        <strong>{{ field.shortTitle|default(field.title)|raw }}</strong>: {{ value }}<br>
     {% endif %}
 {% endfor %}

--- a/Resources/views/mails/notify.html.twig
+++ b/Resources/views/mails/notify.html.twig
@@ -20,6 +20,6 @@
     {% endif %}
 
     {% if value is not empty %}
-        <strong>{{ field.shortTitle|default(field.title)|raw }}</strong>: {{ value }}<br>
+        <strong>{{ field.shortTitle|default(field.title)|raw }}</strong>: {{ value|nl2br }}<br>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #214
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix line breaks in notify emails.

#### Why?

Line breaks should appear in the value

#### To Do

- [x] Update CHANGELOG.md
