### PR TITLE
#194 Add sender the same as parameter for Sender-header on envelope

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('from')->defaultValue('%sulu_admin.email%')->end()
                     ->scalarNode('to')->defaultValue('%sulu_admin.email%')->end()
-                    ->scalarNode('sender')->defaultValue('%sulu_admin.email%')->end()
+                    ->scalarNode('sender')->defaultValue(null)->end()
                     ->arrayNode('templates')
                         ->addDefaultsIfNotSet()
                         ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,6 +52,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('from')->defaultValue('%sulu_admin.email%')->end()
                     ->scalarNode('to')->defaultValue('%sulu_admin.email%')->end()
+                    ->scalarNode('sender')->defaultValue('%sulu_admin.email%')->end()
                     ->arrayNode('templates')
                         ->addDefaultsIfNotSet()
                         ->children()

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -64,6 +64,7 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
 
         $container->setParameter('sulu_form.mail.from', $config['mail']['from']);
         $container->setParameter('sulu_form.mail.to', $config['mail']['to']);
+        $container->setParameter('sulu_form.mail.sender', $config['mail']['sender']);
         $container->setParameter('sulu_form.mail.template.notify', $config['mail']['templates']['notify']);
         $container->setParameter('sulu_form.mail.template.notify_plain_text', $config['mail']['templates']['notify_plain_text']);
         $container->setParameter('sulu_form.mail.template.customer', $config['mail']['templates']['customer']);

--- a/Mail/Helper.php
+++ b/Mail/Helper.php
@@ -41,10 +41,10 @@ class Helper implements HelperInterface
     protected $logger;
 
     /**
-     * @param \Swift_Mailer   $mailer
-     * @param string          $fromMail
-     * @param string          $toMail
-     * @param null|string     $sender
+     * @param \Swift_Mailer $mailer
+     * @param string $fromMail
+     * @param string $toMail
+     * @param string|null $sender
      * @param LoggerInterface $logger
      */
     public function __construct(

--- a/Mail/Helper.php
+++ b/Mail/Helper.php
@@ -96,7 +96,7 @@ class Helper implements HelperInterface
         $message->setFrom($fromMail);
         $message->setTo($toMail);
 
-        if (null !== $this->sender) {
+        if ($this->sender) {
             $message->setSender($this->sender);
         }
 

--- a/Mail/Helper.php
+++ b/Mail/Helper.php
@@ -32,7 +32,9 @@ class Helper implements HelperInterface
      */
     protected $fromMail;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     */
     protected $sender;
 
     /**

--- a/Mail/Helper.php
+++ b/Mail/Helper.php
@@ -32,7 +32,7 @@ class Helper implements HelperInterface
      */
     protected $fromMail;
 
-    /** @var null|string */
+    /** @var string|null */
     protected $sender;
 
     /**

--- a/Mail/Helper.php
+++ b/Mail/Helper.php
@@ -32,26 +32,32 @@ class Helper implements HelperInterface
      */
     protected $fromMail;
 
+    /** @var null|string */
+    protected $sender;
+
     /**
      * @var LoggerInterface
      */
     protected $logger;
 
     /**
-     * @param \Swift_Mailer $mailer
-     * @param string $fromMail
-     * @param string $toMail
+     * @param \Swift_Mailer   $mailer
+     * @param string          $fromMail
+     * @param string          $toMail
+     * @param null|string     $sender
      * @param LoggerInterface $logger
      */
     public function __construct(
         \Swift_Mailer $mailer,
         $fromMail,
         $toMail,
+        $sender = null,
         $logger = null
     ) {
         $this->mailer = $mailer;
         $this->toMail = $toMail;
         $this->fromMail = $fromMail;
+        $this->sender = $sender;
         $this->logger = $logger ?: new NullLogger();
     }
 
@@ -89,6 +95,10 @@ class Helper implements HelperInterface
 
         $message->setFrom($fromMail);
         $message->setTo($toMail);
+
+        if (null !== $this->sender) {
+            $message->setSender($this->sender);
+        }
 
         // Add attachments to the Swift Message
         if (count($attachments) > 0) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,6 +21,7 @@
             <argument type="service" id="mailer" />
             <argument>%sulu_form.mail.from%</argument>
             <argument>%sulu_form.mail.to%</argument>
+            <argument>%sulu_form.mail.sender%</argument>
             <argument type="service" id="logger" />
         </service>
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -41,6 +41,7 @@ sulu_form:
     mail:
         from: "%sulu_admin.email%"
         to:   "%sulu_admin.email%"
+        sender: "%sulu_admin.email%"
 ```
 
 ## Create Database


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #194 

#### What's in this PR?

Add extra "sender" configuration parameter to add a Sender-header to the mail envelope.
