### PR TITLE
Add possibility for a honeypot field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,5 @@ install:
 
 script:
   - if [[ LINT == 'true' ]]; then composer lint; fi
-  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit
 
-after_script:
-  - if [[ $CODE_COVERAGE == 'true' ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi
-  - if [[ $CODE_COVERAGE == 'true' ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover ; fi

--- a/Configuration/FormConfigurationFactory.php
+++ b/Configuration/FormConfigurationFactory.php
@@ -231,13 +231,20 @@ class FormConfigurationFactory
             return null;
         }
 
+        $customerEmail = $this->getEmailFromDynamic($dynamic);
+
+        if (!$customerEmail) {
+            return null;
+        }
+
         $websiteMailConfiguration = $this->createMailConfiguration($locale);
 
         $websiteMailConfiguration->setSubject($translation->getSubject());
         $websiteMailConfiguration->setFrom(
             $this->getEmail($translation->getFromEmail(), $translation->getFromName())
         );
-        $websiteMailConfiguration->setTo($this->getEmailFromDynamic($dynamic));
+
+        $websiteMailConfiguration->setTo($customerEmail);
 
         // Set attachment configuration.
         $websiteMailConfiguration->setAddAttachments($translation->getSendAttachments());
@@ -322,7 +329,7 @@ class FormConfigurationFactory
      *
      * @return string[]|null
      */
-    private function getEmail(string $email, ?string $name = null): ?array
+    private function getEmail(?string $email, ?string $name = null): ?array
     {
         if (!$email) {
             return null;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -99,14 +99,19 @@ class Configuration implements ConfigurationInterface
                 ->normalizeKeys(false)
                 ->prototype('scalar')->end()->defaultValue([])
             ->end()
-            ->scalarNode('dynamic_honeypot_field')->defaultValue(null)->end()
-            ->enumNode('dynamic_honeypot_strategy')
-                ->defaultValue(HandlerInterface::HONEY_POT_STRATEGY_SPAM)
-                ->values([
-                    HandlerInterface::HONEY_POT_STRATEGY_SPAM,
-                    HandlerInterface::HONEY_POT_STRATEGY_NO_EMAIL,
-                    HandlerInterface::HONEY_POT_STRATEGY_NO_SAVE,
-                ])
+            ->arrayNode('honeypot')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('field')->defaultValue(null)->end()
+                    ->enumNode('strategy')
+                        ->defaultValue(HandlerInterface::HONEY_POT_STRATEGY_SPAM)
+                        ->values([
+                            HandlerInterface::HONEY_POT_STRATEGY_SPAM,
+                            HandlerInterface::HONEY_POT_STRATEGY_NO_EMAIL,
+                            HandlerInterface::HONEY_POT_STRATEGY_NO_SAVE,
+                        ])
+                    ->end()
+                ->end()
             ->end()
             ->arrayNode('dynamic_disabled_types')
                 ->prototype('scalar')->end()->defaultValue([])

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\FormBundle\DependencyInjection;
 
+use Sulu\Bundle\FormBundle\Form\HandlerInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -97,6 +98,15 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('ajax_templates')
                 ->normalizeKeys(false)
                 ->prototype('scalar')->end()->defaultValue([])
+            ->end()
+            ->scalarNode('dynamic_honeypot_field')->defaultValue(null)->end()
+            ->enumNode('dynamic_honeypot_strategy')
+                ->defaultValue(HandlerInterface::HONEY_POT_STRATEGY_SPAM)
+                ->values([
+                    HandlerInterface::HONEY_POT_STRATEGY_SPAM,
+                    HandlerInterface::HONEY_POT_STRATEGY_NO_EMAIL,
+                    HandlerInterface::HONEY_POT_STRATEGY_NO_SAVE,
+                ])
             ->end()
             ->arrayNode('dynamic_disabled_types')
                 ->prototype('scalar')->end()->defaultValue([])

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -165,13 +165,13 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         );
 
         $container->setParameter(
-            'sulu_form.dynamic_honeypot_field',
-            $config['dynamic_honeypot_field']
+            'sulu_form.honeypot_field',
+            $config['honeypot']['field']
         );
 
         $container->setParameter(
-            'sulu_form.dynamic_honeypot_strategy',
-            $config['dynamic_honeypot_strategy']
+            'sulu_form.honeypot_strategy',
+            $config['honeypot']['strategy']
         );
 
         // Load services

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -164,6 +164,16 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
             $config['dynamic_list_builder']['delimiter']
         );
 
+        $container->setParameter(
+            'sulu_form.dynamic_honeypot_field',
+            $config['dynamic_honeypot_field']
+        );
+
+        $container->setParameter(
+            'sulu_form.dynamic_honeypot_strategy',
+            $config['dynamic_honeypot_strategy']
+        );
+
         // Load services
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');

--- a/Form/HandlerInterface.php
+++ b/Form/HandlerInterface.php
@@ -19,5 +19,16 @@ interface HandlerInterface
     const EVENT_FORM_SAVE = 'sulu_form.handler.save';
     const EVENT_FORM_SAVED = 'sulu_form.handler.saved';
 
+    const HONEY_POT_STRATEGY_NO_SAVE = 'no_save';
+    const HONEY_POT_STRATEGY_NO_EMAIL = 'no_email';
+    const HONEY_POT_STRATEGY_SPAM = 'spam';
+
+    /**
+     * @param FormInterface $form
+     * @param FormConfigurationInterface $configuration
+     *
+     * @return bool
+     */
+
     public function handle(FormInterface $form, FormConfigurationInterface $configuration): bool;
 }

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\FormBundle\Entity\Dynamic;
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -35,12 +36,25 @@ class DynamicFormType extends AbstractType
      */
     private $checksum;
 
+    /**
+     * @var string|null
+     */
+    private $honeyPotField;
+
+    /**
+     * DynamicFormType constructor.
+     *
+     * @param FormFieldTypePool $typePool
+     * @param Checksum $checksum
+     */
     public function __construct(
         FormFieldTypePool $typePool,
-        Checksum $checksum
+        Checksum $checksum,
+        ?string $honeyPotField = null
     ) {
         $this->typePool = $typePool;
         $this->checksum = $checksum;
+        $this->honeyPotField = $honeyPotField;
     }
 
     /**
@@ -141,6 +155,17 @@ class DynamicFormType extends AbstractType
             'data' => $checksum,
             'mapped' => false,
         ]);
+
+        if ($this->honeyPotField) {
+            $builder->add(
+                str_replace(' ', '_', strtolower($this->honeyPotField)),
+                EmailType::class,
+                [
+                    'label' => $this->honeyPotField,
+                    'mapped' => false,
+                ]
+            );
+        }
 
         // Add submit button.
         $builder->add(

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -164,6 +164,7 @@ class DynamicFormType extends AbstractType
                     'label' => $this->honeyPotField,
                     'mapped' => false,
                     'block_prefix' => 'honeypot',
+                    'required' => false,
                 ]
             );
         }

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -163,6 +163,7 @@ class DynamicFormType extends AbstractType
                 [
                     'label' => $this->honeyPotField,
                     'mapped' => false,
+                    'block_prefix' => 'honeypot',
                 ]
             );
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,8 @@
             <argument type="service" id="twig" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sulu_media.media_manager" />
-            <argument type="service" id="logger" />
+            <argument>%sulu_form.dynamic_honeypot_strategy%%</argument>
+            <argument>%sulu_form.dynamic_honeypot_field%</argument>
         </service>
         <service id="Sulu\Bundle\FormBundle\Form\HandlerInterface" alias="sulu_form.handler"/>
 
@@ -95,6 +96,7 @@
         <service id="sulu_form.form_type" class="Sulu\Bundle\FormBundle\Form\Type\DynamicFormType">
             <argument type="service" id="sulu_form.dynamic.form_field_type_pool" />
             <argument type="service" id="sulu_form.checksum" />
+            <argument>%sulu_form.dynamic_honeypot_field%</argument>
 
             <tag name="form.type"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,8 +13,8 @@
             <argument type="service" id="twig" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sulu_media.media_manager" />
-            <argument>%sulu_form.dynamic_honeypot_strategy%%</argument>
-            <argument>%sulu_form.dynamic_honeypot_field%</argument>
+            <argument>%sulu_form.honeypot_strategy%</argument>
+            <argument>%sulu_form.honeypot_field%</argument>
         </service>
         <service id="Sulu\Bundle\FormBundle\Form\HandlerInterface" alias="sulu_form.handler"/>
 
@@ -96,7 +96,7 @@
         <service id="sulu_form.form_type" class="Sulu\Bundle\FormBundle\Form\Type\DynamicFormType">
             <argument type="service" id="sulu_form.dynamic.form_field_type_pool" />
             <argument type="service" id="sulu_form.checksum" />
-            <argument>%sulu_form.dynamic_honeypot_field%</argument>
+            <argument>%sulu_form.honeypot_field%</argument>
 
             <tag name="form.type"/>
         </service>

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -172,6 +172,30 @@ php bin/adminconsole debug:container --tag=sulu_form.dynamic.type
 
 **Provider for type "structure" already exists**
 
+## Add Honeypot field for spam protection
+
+If you want to add a honeypot field for spam protection you can activate it the following way:
+
+```yaml
+sulu_form:
+    dynamic_honeypot_field: "Honey Pot Field Name"
+    dynamic_honeypot_strategy: spam # no_save, no_email, spam
+```
+
+There are 3 honeypot strategies:
+
+**spam**
+
+Spam is the default behaviour and it will just mark the email subject with a prefix `(SPAM) `.
+
+**no_email**
+
+This option will save the form if enabled but will not send any emails.
+
+**no_save**
+
+Will not save and will not send any emails.
+
 ## Media Collections
 
 To create for every form and page an own collection you need to configure the following in your `config/packages/sulu_form.yaml`:

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -178,8 +178,9 @@ If you want to add a honeypot field for spam protection you can activate it the 
 
 ```yaml
 sulu_form:
-    dynamic_honeypot_field: "Honey Pot Field Name"
-    dynamic_honeypot_strategy: spam # no_save, no_email, spam
+    honeypot:
+        field: "Honey Pot Field Name"
+        strategy: spam # no_save, no_email, spam
 ```
 
 There are 3 honeypot strategies:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #212
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Add possibility for a honeypot field

#### Why?

To avoid spams

#### Example Usage

```yaml
sulu_form:
    dynamic_honeypot_field: "Honey Pot Field Name"
    dynamic_honeypot_strategy: spam # no_save, no_email, spam
```

#### To Do

- [ ] Update CHANGELOG.md
- [x] Create documentation

