### PR TITLE
Remove filter type attributes from form list definition

### DIFF
--- a/Resources/config/lists/forms.xml
+++ b/Resources/config/lists/forms.xml
@@ -33,7 +33,6 @@
                 name="title"
                 visibility="always"
                 searchability="yes"
-                filter-type="string"
                 translation="sulu_form.title">
             <field>
                 <field-name>title</field-name>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #228 
| Related issues/PRs | #228 
| License | MIT

#### What's in this PR?

Removes filter type attribute

#### Why?

To make the bundle compatible with sulu 2.1.*@dev

