### PR TITLE
Fixed nullable form field translation

### DIFF
--- a/Entity/FormFieldTranslation.php
+++ b/Entity/FormFieldTranslation.php
@@ -17,7 +17,7 @@ namespace Sulu\Bundle\FormBundle\Entity;
 class FormFieldTranslation
 {
     /**
-     * @var string
+     * @var null|string
      */
     private $title;
 
@@ -56,14 +56,14 @@ class FormFieldTranslation
      */
     private $options;
 
-    public function setTitle(string $title): self
+    public function setTitle(?string $title): self
     {
         $this->title = $title;
 
         return $this;
     }
 
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixes the type hints for the `$title` of the `FormFieldTranslation.php` as it is nullable.

#### Why?

Because it's not possible to save a form with a field that doesn't have a title, e.g. the `spacer`.

Currently following error is displayed:
```
message: "Argument 1 passed to Sulu\Bundle\FormBundle\Entity\FormFieldTranslation::setTitle() must be of the type string, null given, called in /Users/thomas.duenser/Development/websites/zuend.lo/vendor/sulu/sulu-form-bundle/Manager/FormManager.php on line 215"
```
