### PR TITLE
Rename package to sulu/form-bundle

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -14,7 +14,7 @@ The `mail` dispatching is handled by the bundle.
 ## Installation
 
 ```bash
-composer require sulu/sulu-form-bundle
+composer require sulu/form-bundle
 ```
 
 Add to AbstractKernel (app/AbstractKernel.php)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sulu/sulu-form-bundle",
+    "name": "sulu/form-bundle",
     "description": "Bundle for creating forms in Sulu.",
     "type": "sulu-bundle",
     "require": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/SuluFormBundle/issues/223
| License | MIT

#### What's in this PR?

Renames the package name to `sulu\form-bundle`.

#### Why?

Because we want consistency between all sulu-bundles.

#### TODO

 - [x] rename in composer.json
 - [ ] publish with new name
 - [ ] abandoned old name and link to new package
 - [ ] rename **crowdin** project
