### PR TITLE
Remove paragraphs from labels

### DIFF
--- a/Entity/FormFieldTranslation.php
+++ b/Entity/FormFieldTranslation.php
@@ -58,6 +58,16 @@ class FormFieldTranslation
 
     public function setTitle(?string $title): self
     {
+        if ($title) {
+            // this is a replacement for enterMode br which does not longer exist in ckeditor 5
+            // see also https://github.com/sulu/sulu/issues/5214
+            $title = str_replace(
+                ['</p><p>', '<p>', '</p>'],
+                ['<br/><br/>', '', ''],
+                $title
+            );
+        }
+
         $this->title = $title;
 
         return $this;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Remove paragraphs from labels

#### Why?

Currently ckeditor will always wrap around labels this can be removed when https://github.com/sulu/sulu/issues/5214 is fixed.

#### To Do

- [ ] Create documentation
