### PR TITLE
Fix field order after save

### DIFF
--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -366,6 +366,11 @@ class FormController extends AbstractRestController implements ClassResourceInte
             $fields[] = $fieldData;
         }
 
+        // Sort fields with correct order
+        usort($fields, function($fieldA, $fieldB) {
+            return $fieldA['order'] > $fieldB['order'];
+        });
+
         // Api Entity
         return array_merge(
             [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related issue | #245 
| Deprecations? | no
| License | MIT

#### What's in this PR?

A fix for the sorting issue on save

#### Why?

When you save the form after you sorted some fields, the fields get reset to it's original position until page reload.