### PR TITLE
Fix/radio options cant edit

### DIFF
--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -366,6 +366,11 @@ class FormController extends AbstractRestController implements ClassResourceInte
             $fields[] = $fieldData;
         }
 
+        // Sort fields with correct order
+        usort($fields, function($fieldA, $fieldB) {
+            return $fieldA['order'] > $fieldB['order'];
+        });
+
         // Api Entity
         return array_merge(
             [

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -364,7 +364,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
             }
 
             if (empty($fieldData['options'])) {
-                $fieldData['options'] = new stdClass(); // convert options to "{}"
+                $fieldData['options'] = new \stdClass(); // convert options to "{}"
             }
 
             $fields[] = $fieldData;

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -366,11 +366,6 @@ class FormController extends AbstractRestController implements ClassResourceInte
             $fields[] = $fieldData;
         }
 
-        // Sort fields with correct order
-        usort($fields, function($fieldA, $fieldB) {
-            return $fieldA['order'] > $fieldB['order'];
-        });
-
         // Api Entity
         return array_merge(
             [

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -363,6 +363,10 @@ class FormController extends AbstractRestController implements ClassResourceInte
                 $fieldData['options'] = $fieldTranslation->getOptions();
             }
 
+            if ($fieldData['type'] === 'radioButtons' && empty($fieldData['options'])) {
+                $fieldData['options']['choices'] = [];
+            }
+
             $fields[] = $fieldData;
         }
 

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -363,9 +363,8 @@ class FormController extends AbstractRestController implements ClassResourceInte
                 $fieldData['options'] = $fieldTranslation->getOptions();
             }
 
-            $choiceFields = ['dropdown', 'radioButtons'];
-            if (in_array($fieldData['type'], $choiceFields) && empty($fieldData['options'])) {
-                $fieldData['options']['choices'] = [];
+            if (empty($fieldData['options'])) {
+                $fieldData['options'] = new stdClass(); // convert options to "{}"
             }
 
             $fields[] = $fieldData;

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -363,7 +363,8 @@ class FormController extends AbstractRestController implements ClassResourceInte
                 $fieldData['options'] = $fieldTranslation->getOptions();
             }
 
-            if ($fieldData['type'] === 'radioButtons' && empty($fieldData['options'])) {
+            $choiceFields = ['dropdown', 'radioButtons'];
+            if (in_array($fieldData['type'], $choiceFields) && empty($fieldData['options'])) {
                 $fieldData['options']['choices'] = [];
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related issue | #209
| Deprecations? | no
| License | MIT

#### What's in this PR?

A fix where you could not type inside the choices area of a radiobutton

#### Why?

When the translation does not exist, the options of a radio button return [], this has conflicts with react so when options is empty I now return { choices: [] } for the radio button type only.