### PR TITLE
Fix dynamic list builder media urls

### DIFF
--- a/ListBuilder/DynamicListBuilder.php
+++ b/ListBuilder/DynamicListBuilder.php
@@ -95,7 +95,12 @@ class DynamicListBuilder implements DynamicListBuilderInterface
         return implode($this->delimiter, $value);
     }
 
-    protected function getMediaUrls(string $value): string
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function getMediaUrls($value): string
     {
         if (is_string($value)) {
             return $this->getMediaUrl($value);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #249 
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Allow string|array in getMediaUrls.

#### Why?

Fix dynamic list builder media urls.

