### PR TITLE
Avoid magic setter and getter in dynamic form

### DIFF
--- a/Entity/Dynamic.php
+++ b/Entity/Dynamic.php
@@ -106,9 +106,7 @@ class Dynamic implements AuditableInterface
         $this->webspaceKey = $webspaceKey;
         $this->typeName = $typeName;
 
-        foreach ($data as $name => $value) {
-            $this->__set($name, $value);
-        }
+        $this->setData($data);
     }
 
     /**
@@ -119,20 +117,11 @@ class Dynamic implements AuditableInterface
         return json_decode($this->data, true);
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function __set(string $key, $value): void
+    public function setData(array $data): self
     {
-        $this->setField($key, $value);
-    }
+        $this->data = json_encode($data, JSON_UNESCAPED_UNICODE);
 
-    /**
-     * @return mixed
-     */
-    public function __get(string $name)
-    {
-        return $this->getField($name);
+        return $this;
     }
 
     /**

--- a/Entity/Form.php
+++ b/Entity/Form.php
@@ -203,7 +203,7 @@ class Form
             $value = null;
 
             if ($dynamic) {
-                $value = $dynamic->{$field->getKey()};
+                $value = $dynamic->getField($field->getKey());
             }
 
             $fields[$field->getOrder()] = [

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -87,6 +87,7 @@ class DynamicFormType extends AbstractType
                 'constraints' => [],
                 'attr' => [],
                 'translation_domain' => false,
+                'property_path' => 'data[' . $field->getKey() . ']',
             ];
 
             $title = $fieldTranslation->getTitle();

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -286,6 +286,25 @@ sulu_form.token:
         _requestAnalyzer: false
 ```
 
+### Dynamic magic getter and setter removed
+
+The magic setter of the `Dynamic?  entity was removed:
+
+**before**:
+
+```php
+$dynamic->__set($key, $value);
+$dynamic->__get($key);
+$dynamic->{$key};
+```
+
+**after**:
+
+```php
+$dynamic->setField($key, $value);
+$dynamic->getField($key);
+```
+
 ### Token Controller moved
 
 The tokenAction was moved into an own Controller:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | part of #190  
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Avoid magic setter and getter in dynamic form.

#### Why?

Magic setter and getter should always be avoided.

