### PR TITLE
Make from and to email not required

### DIFF
--- a/Resources/config/forms/form_details.xml
+++ b/Resources/config/forms/form_details.xml
@@ -40,7 +40,7 @@
                         <title>sulu_form.subject</title>
                     </meta>
                 </property>
-                <property name="fromEmail" type="email" colspan="6" mandatory="true">
+                <property name="fromEmail" type="email" colspan="6">
                     <meta>
                         <title>sulu_form.from_email</title>
                     </meta>
@@ -50,7 +50,7 @@
                         <title>sulu_form.from_name</title>
                     </meta>
                 </property>
-                <property name="toEmail" type="email" colspan="6" mandatory="true">
+                <property name="toEmail" type="email" colspan="6">
                     <meta>
                         <title>sulu_form.to_email</title>
                     </meta>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #256 
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Make from and to email in form details not required, because they fallback to configured from and to emails.

If no email addresses are configured and no email addresses are entered in the form details, form submit works, but no email is being sent.