### PR TITLE
Fix example configration using %env(SULU_ADMIN_EMAIL)%

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -41,9 +41,9 @@ Configure the default sender and receivers email address (optional):
 ```yml
 sulu_form:
     mail:
-        from: "%sulu_admin.email%"
-        to:   "%sulu_admin.email%"
-        sender: "%sulu_admin.email%"
+        from: "%env(SULU_ADMIN_EMAIL)%"
+        to:   "%env(SULU_ADMIN_EMAIL)%"
+        sender: "%env(SULU_ADMIN_EMAIL)%"
 ```
 
 ## Create Database


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Fix example configration using %env(SULU_ADMIN_EMAIL)%.

#### Why?

The current configuration is  using a parameter which maybe not exist.

#### To Do

- [x] Create documentation
