### PR TITLE
Add deactivate attachment save flag

### DIFF
--- a/Configuration/FormConfiguration.php
+++ b/Configuration/FormConfiguration.php
@@ -32,6 +32,11 @@ class FormConfiguration implements FormConfigurationInterface
     private $fileFields = [];
 
     /**
+     * @var bool
+     */
+    private $fileSave = true;
+
+    /**
      * @var MailConfigurationInterface
      */
     private $adminMailConfiguration;
@@ -116,6 +121,18 @@ class FormConfiguration implements FormConfigurationInterface
     public function setFileFields(array $fileFields)
     {
         $this->fileFields = $fileFields;
+
+        return $this;
+    }
+
+    public function getFileSave(): bool
+    {
+        return $this->fileSave;
+    }
+
+    public function setFileSave(bool $fileSave)
+    {
+        $this->fileSave = $fileSave;
 
         return $this;
     }

--- a/Configuration/FormConfigurationFactory.php
+++ b/Configuration/FormConfigurationFactory.php
@@ -64,8 +64,13 @@ class FormConfigurationFactory
      */
     public function buildByDynamic(Dynamic $dynamic): FormConfigurationInterface
     {
-        $config = $this->create($dynamic->getLocale());
+        $form = $dynamic->getForm();
+        $locale = $dynamic->getLocale();
+        $translation = $form->getTranslation($locale);
+
+        $config = $this->create($locale);
         $config->setFileFields($this->getFileFieldsByDynamic($dynamic));
+        $config->setFileSave(!$translation->getDeactivateAttachmentSave());
 
         $adminMailConfiguration = $this->buildAdminMailConfigurationByDynamic($dynamic);
         $websiteMailConfiguration = $this->buildWebsiteMailConfigurationByDynamic($dynamic);

--- a/Configuration/FormConfigurationInterface.php
+++ b/Configuration/FormConfigurationInterface.php
@@ -34,6 +34,13 @@ interface FormConfigurationInterface
     public function getFileFields(): array;
 
     /**
+     * Should the files be saved.
+     *
+     * @return bool
+     */
+    public function getFileSave(): bool;
+
+    /**
      * Get admin mail configuration.
      */
     public function getAdminMailConfiguration(): ?MailConfigurationInterface;

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -330,6 +330,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
                 'submitLabel' => $translation->getSubmitLabel(),
                 'successText' => $translation->getSuccessText(),
                 'sendAttachments' => $translation->getSendAttachments(),
+                'deactivateAttachmentSave' => $translation->getDeactivateAttachmentSave(),
                 'deactivateNotifyMails' => $translation->getDeactivateNotifyMails(),
                 'deactivateCustomerMails' => $translation->getDeactivateCustomerMails(),
                 'receivers' => $receivers,

--- a/Entity/FormTranslation.php
+++ b/Entity/FormTranslation.php
@@ -74,6 +74,11 @@ class FormTranslation implements AuditableInterface
     /**
      * @var bool
      */
+    private $deactivateAttachmentSave = false;
+
+    /**
+     * @var bool
+     */
     private $deactivateNotifyMails = false;
 
     /**
@@ -249,6 +254,18 @@ class FormTranslation implements AuditableInterface
     public function getSendAttachments(): bool
     {
         return $this->sendAttachments;
+    }
+
+    public function getDeactivateAttachmentSave(): bool
+    {
+        return $this->deactivateAttachmentSave;
+    }
+
+    public function setDeactivateAttachmentSave(bool $deactivateAttachmentSave): self
+    {
+        $this->deactivateAttachmentSave = $deactivateAttachmentSave;
+
+        return $this;
     }
 
     public function setDeactivateNotifyMails(bool $deactivateNotifyMails): self

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -92,7 +92,7 @@ class FormManager
         $translation->setSubmitLabel(self::getValue($data, 'submitLabel'));
         $translation->setSuccessText(self::getValue($data, 'successText'));
         $translation->setSendAttachments(self::getValue($data, 'sendAttachments', false));
-        $translation->setDeactivateAttachmentSave(self::getValue($data, 'deactivateAttachmentSave', false));
+        $translation->setDeactivateAttachmentSave($translation->getSendAttachments() && self::getValue($data, 'deactivateAttachmentSave', false));
         $translation->setDeactivateNotifyMails(self::getValue($data, 'deactivateNotifyMails', false));
         $translation->setDeactivateCustomerMails(self::getValue($data, 'deactivateCustomerMails', false));
         $translation->setReplyTo(self::getValue($data, 'replyTo', false));

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -92,6 +92,7 @@ class FormManager
         $translation->setSubmitLabel(self::getValue($data, 'submitLabel'));
         $translation->setSuccessText(self::getValue($data, 'successText'));
         $translation->setSendAttachments(self::getValue($data, 'sendAttachments', false));
+        $translation->setDeactivateAttachmentSave(self::getValue($data, 'deactivateAttachmentSave', false));
         $translation->setDeactivateNotifyMails(self::getValue($data, 'deactivateNotifyMails', false));
         $translation->setDeactivateCustomerMails(self::getValue($data, 'deactivateCustomerMails', false));
         $translation->setReplyTo(self::getValue($data, 'replyTo', false));

--- a/Resources/config/doctrine/FormTranslation.orm.xml
+++ b/Resources/config/doctrine/FormTranslation.orm.xml
@@ -23,6 +23,11 @@
                 <option name="default">0</option>
             </options>
         </field>
+        <field name="deactivateAttachmentSave" column="deactivateAttachmentSave" type="boolean" nullable="false">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
         <field name="deactivateNotifyMails" column="deactivateNotifyMails" type="boolean" nullable="false">
             <options>
                 <option name="default">0</option>

--- a/Resources/config/forms/form_details.xml
+++ b/Resources/config/forms/form_details.xml
@@ -3,7 +3,9 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:xi="http://www.w3.org/2001/XInclude"
       xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
+
     <key>form_details</key>
+
     <properties>
         <property name="title" type="text_line" mandatory="true">
             <meta>
@@ -13,16 +15,19 @@
                 <param name="headline" value="true"/>
             </params>
         </property>
+
         <section name="websiteConfiguration">
             <meta>
                 <title>sulu_form.website_configuration</title>
             </meta>
+
             <properties>
                 <property name="submitLabel" type="text_line">
                     <meta>
                         <title>sulu_form.submit_label</title>
                     </meta>
                 </property>
+
                 <property name="successText" type="text_editor">
                     <meta>
                         <title>sulu_form.success_text</title>
@@ -30,87 +35,116 @@
                 </property>
             </properties>
         </section>
+
         <section name="emailConfiguration">
             <meta>
                 <title>sulu_form.email_configuration</title>
             </meta>
+
             <properties>
                 <property name="subject" type="text_line">
                     <meta>
                         <title>sulu_form.subject</title>
                     </meta>
                 </property>
+
                 <property name="fromEmail" type="email" colspan="6">
                     <meta>
                         <title>sulu_form.from_email</title>
                     </meta>
                 </property>
+
                 <property name="fromName" type="text_line" colspan="6">
                     <meta>
                         <title>sulu_form.from_name</title>
                     </meta>
                 </property>
+
                 <property name="toEmail" type="email" colspan="6">
                     <meta>
                         <title>sulu_form.to_email</title>
                     </meta>
                 </property>
+
                 <property name="toName" type="text_line" colspan="6">
                     <meta>
                         <title>sulu_form.to_name</title>
                     </meta>
                 </property>
+
                 <property name="mailText" type="text_editor">
                     <meta>
                         <title>sulu_form.success_text</title>
                     </meta>
                 </property>
-                <property name="replyTo" type="checkbox" colspan="6">
-                    <params>
-                        <param name="label">
-                            <meta>
-                                <title>sulu_form.user_as_reply_to</title>
-                            </meta>
-                        </param>
-                        <param name="type" value="toggler"/>
-                    </params>
-                </property>
-                <property name="sendAttachments" type="checkbox" colspan="6">
-                    <params>
-                        <param name="label">
-                            <meta>
-                                <title>sulu_form.send_attachments</title>
-                            </meta>
-                        </param>
-                        <param name="type" value="toggler"/>
-                    </params>
-                </property>
-                <property name="deactivateNotifyMails" type="checkbox" colspan="6">
+
+                <property name="deactivateNotifyMails" type="checkbox" colspan="4">
                     <params>
                         <param name="label">
                             <meta>
                                 <title>sulu_form.deactivate_notify</title>
                             </meta>
                         </param>
+
                         <param name="type" value="toggler"/>
                     </params>
                 </property>
-                <property name="deactivateCustomerMails" type="checkbox" colspan="6">
+
+                <property name="deactivateCustomerMails" type="checkbox" colspan="4" spaceAfter="4">
                     <params>
                         <param name="label">
                             <meta>
                                 <title>sulu_form.deactivate_success</title>
                             </meta>
                         </param>
+
+                        <param name="type" value="toggler"/>
+                    </params>
+                </property>
+
+                <property name="replyTo" type="checkbox" colspan="4">
+                    <params>
+                        <param name="label">
+                            <meta>
+                                <title>sulu_form.user_as_reply_to</title>
+                            </meta>
+                        </param>
+
+                        <param name="type" value="toggler"/>
+                    </params>
+                </property>
+
+                <property name="sendAttachments" type="checkbox" colspan="4">
+                    <params>
+                        <param name="label">
+                            <meta>
+                                <title>sulu_form.send_attachments</title>
+                            </meta>
+                        </param>
+
+                        <param name="type" value="toggler"/>
+                    </params>
+                </property>
+
+                <property name="deactivateAttachmentSave" type="checkbox" colspan="4" visibleCondition="sendAttachments">
+                    <params>
+                        <param name="label">
+                            <meta>
+                                <title>sulu_form.deactivate_attachment_save</title>
+                            </meta>
+                        </param>
+
                         <param name="type" value="toggler"/>
                     </params>
                 </property>
             </properties>
         </section>
+
         <section name="receivers">
             <meta>
                 <title>sulu_form.receivers</title>
             </meta>
+
             <properties>
                 <block name="receivers" default-type="to">
                     <types>
@@ -118,12 +152,14 @@
                             <meta>
                                 <title>sulu_form.receiver.to</title>
                             </meta>
+
                             <properties>
                                 <property name="email" type="email" colspan="6" mandatory="true">
                                     <meta>
                                         <title>sulu_form.email</title>
                                     </meta>
                                 </property>
+
                                 <property name="name" type="text_line" colspan="6">
                                     <meta>
                                         <title>sulu_form.receiver.name</title>
@@ -131,16 +167,19 @@
                                 </property>
                             </properties>
                         </type>
+
                         <type name="cc">
                             <meta>
                                 <title>sulu_form.receiver.cc</title>
                             </meta>
+
                             <properties>
                                 <property name="email" type="email" colspan="6" mandatory="true">
                                     <meta>
                                         <title>sulu_form.email</title>
                                     </meta>
                                 </property>
+
                                 <property name="name" type="text_line" colspan="6">
                                     <meta>
                                         <title>sulu_form.receiver.name</title>
@@ -148,16 +187,19 @@
                                 </property>
                             </properties>
                         </type>
+
                         <type name="bcc">
                             <meta>
                                 <title>sulu_form.receiver.bcc</title>
                             </meta>
+
                             <properties>
                                 <property name="email" type="email" colspan="6" mandatory="true">
                                     <meta>
                                         <title>sulu_form.email</title>
                                     </meta>
                                 </property>
+
                                 <property name="name" type="text_line" colspan="6">
                                     <meta>
                                         <title>sulu_form.receiver.name</title>

--- a/Resources/translations/admin.de.json
+++ b/Resources/translations/admin.de.json
@@ -15,6 +15,7 @@
   "sulu_form.to_name": "Empfänger: Name",
   "sulu_form.user_as_reply_to": "\"Reply-to\" Adresse automatisch ausfüllen",
   "sulu_form.send_attachments": "Anhang versenden?",
+  "sulu_form.deactivate_attachment_save": "Anhang Speichern deaktivieren",
   "sulu_form.deactivate_notify": "Benachrichtungsemails deaktivieren",
   "sulu_form.deactivate_success": "Bestätigungsemails deaktivieren",
   "sulu_form.receivers": "Empfänger",

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -15,6 +15,7 @@
   "sulu_form.to_name": "Receiver: Name",
   "sulu_form.user_as_reply_to": "Autofill \"reply-to\" address",
   "sulu_form.send_attachments": "Send attachments?",
+  "sulu_form.deactivate_attachment_save": "Deactivate attachment save",
   "sulu_form.deactivate_notify": "Deactivate Notifymails",
   "sulu_form.deactivate_success": "Deactivate Successmails",
   "sulu_form.receivers": "Receivers",

--- a/Resources/views/mails/notify.html.twig
+++ b/Resources/views/mails/notify.html.twig
@@ -1,29 +1,30 @@
-{% for field in formEntity.fields|default([]) %}
-    {% set value = field.value %}
+{% for field in formEntity.fields|default([]) -%}
+    {%- set value = field.value -%}
 
     {# get formatted value. #}
-    {% if value is iterable %}
-        {% if field.type == 'attachment' %}
-            {% set mediaUrls = [] %}
-            {% for mediaId in field.value %}
-                {% set media = sulu_resolve_media(mediaId, app.request.locale) %}
-                {% set mediaUrls = mediaUrls|merge(['<a href="' ~ absolute_url(media.url) ~ '">' ~ media.title ~ '</a>']) %}
-            {% endfor %}
-            {% set value %}
-                {{ mediaUrls|join(', ')|raw  }}
-            {% endset %}
-        {% else %}
-            {% set value = value|json_encode %}
-        {% endif %}
-    {% elseif value.timestamp is defined %}
-        {% set value = value|date('d.m.Y') %}
-    {% else %}
-        {% set value %}
+    {%- if value is iterable -%}
+        {%- if field.type == 'attachment' -%}
+            {%- set mediaUrls = [] -%}
+            {%- for mediaId in field.value -%}
+                {%- set media = sulu_resolve_media(mediaId, app.request.locale) -%}
+                {%- set mediaUrls = mediaUrls|merge(['<a href="' ~ absolute_url(media.url) ~ '">' ~ media.title ~ '</a>']) -%}
+            {%- endfor -%}
+            {%- set value -%}
+                {{- mediaUrls|join(', ')|raw -}}
+            {%- endset -%}
+        {%- else -%}
+            {%- set value = value|json_encode -%}
+        {%- endif -%}
+    {%- elseif value.timestamp is defined -%}
+        {% set value = value|date('d.m.Y') -%}
+    {%- else -%}
+        {%- set value -%}
             {{- value|nl2br -}}
-        {% endset %}
-    {% endif %}
+        {%- endset -%}
+    {%- endif -%}
 
-    {% if value is not empty %}
+    {%- if value is not empty and field.value is not empty -%}
+        {#- fix breaks #}
         <strong>{{ field.shortTitle|default(field.title)|raw }}</strong>: {{ value }}<br>
     {% endif %}
 {% endfor %}

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -205,6 +205,7 @@ class FormControllerTest extends SuluTestCase
         $this->assertFalse($response['deactivateCustomerMails']);
         $this->assertFalse($response['deactivateNotifyMails']);
         $this->assertFalse($response['sendAttachments']);
+        $this->assertFalse($response['deactivateAttachmentSave']);
         $this->assertEquals('testing@example.com', $response['fromEmail']);
         $this->assertEquals('testing@example.com', $response['toEmail']);
         $this->assertNull($response['fromName']);
@@ -231,6 +232,7 @@ class FormControllerTest extends SuluTestCase
         $this->assertTrue($response['deactivateCustomerMails']);
         $this->assertTrue($response['deactivateNotifyMails']);
         $this->assertTrue($response['sendAttachments']);
+        $this->assertTrue($response['deactivateAttachmentSave']);
         $this->assertEquals('from@example.org', $response['fromEmail']);
         $this->assertEquals('to@example.org', $response['toEmail']);
         $this->assertEquals('From', $response['fromName']);
@@ -410,6 +412,7 @@ class FormControllerTest extends SuluTestCase
             'deactivateCustomerMails' => true,
             'deactivateNotifyMails' => true,
             'sendAttachments' => true,
+            'deactivateAttachmentSave' => true,
             'fromEmail' => 'from@example.org',
             'toEmail' => 'to@example.org',
             'fromName' => 'From',

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -216,7 +216,7 @@ class FormControllerTest extends SuluTestCase
         // Receivers
         $this->assertCount(0, $response['receivers']);
         // Other fields
-        $this->assertCountFields(17, $response);
+        $this->assertCountFields(18, $response);
     }
 
     private function assertFullForm($response)
@@ -273,7 +273,7 @@ class FormControllerTest extends SuluTestCase
             $this->assertTrue($foundExpectedType);
         }
         // Other
-        $this->assertCountFields(17, $response);
+        $this->assertCountFields(18, $response);
     }
 
     private function assertCountFields($expectedCount, $haystack)
@@ -316,6 +316,7 @@ class FormControllerTest extends SuluTestCase
         $formTranslation->setDeactivateCustomerMails(true);
         $formTranslation->setDeactivateNotifyMails(true);
         $formTranslation->setSendAttachments(true);
+        $formTranslation->setDeactivateAttachmentSave(true);
         $formTranslation->setFromEmail('from@example.org');
         $formTranslation->setFromName('From');
         $formTranslation->setToEmail('to@example.org');

--- a/Tests/Unit/Configuration/FormConfigurationFactoryTest.php
+++ b/Tests/Unit/Configuration/FormConfigurationFactoryTest.php
@@ -95,6 +95,7 @@ class FormConfigurationFactoryTest extends TestCase
         $formTranslation->getDeactivateNotifyMails()->willReturn(false);
         $formTranslation->getDeactivateCustomerMails()->willReturn(false);
         $formTranslation->getSendAttachments()->willReturn(true);
+        $formTranslation->getDeactivateAttachmentSave()->willReturn(false);
         $formTranslation->getReplyTo()->willReturn(true);
         $formTranslation->getSubject()->willReturn('Subject');
         $formTranslation->getFromEmail()->willReturn('from@example.dev');

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,8 @@
 
 ## 2.1.0
 
+### Database
+
 #### Add deactivateAttachmentSave field to form
 
 To allow to deactivate that attachment is saved, the following needed to be adjusted in the database:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade
 
+## 2.1.0
+
+#### Add deactivateAttachmentSave field to form
+
+To allow to deactivate that attachment is saved, the following needed to be adjusted in the database:
+
+```sql
+ALTER TABLE fo_form_translations ADD deactivateAttachmentSave TINYINT(1) DEFAULT '0' NOT NULL;
+```
+
 ## 2.0.0
 
 ### Database


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Add deactivate attachment save flag.

![deactivate-save-media](https://user-images.githubusercontent.com/1698337/101651231-1f735400-3a3d-11eb-9c12-eb716d1c2a2d.gif)

#### Why?

There are client which doesn't want to save any documents and its enough for them to have them in the email process.

#### Example Usage

```bash
bin/console sulu:form:generate-form

# open the generated form and enable send attachment and deactivate save attachment
```

#### TODO

 - [x] Test behaviour
 - [x] Adjust [email template](https://github.com/alexander-schranz/SuluFormBundle/blob/9b1bca48790dee1357e32133965cbfdd3ed787b1/Resources/views/mails/notify.html.twig#L10) when disabled saving of media fields not not be linked
 - [x] Adjusts Tests see https://travis-ci.com/github/alexander-schranz/SuluFormBundle/builds/207510975
