### PR TITLE
Fix caching for forms

### DIFF
--- a/Csrf/DisabledCsrfTokenManager.php
+++ b/Csrf/DisabledCsrfTokenManager.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Csrf;
+
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class DisabledCsrfTokenManager implements CsrfTokenManagerInterface
+{
+    public function refreshToken(string $tokenId)
+    {
+        throw new \RuntimeException('Should not be called');
+    }
+
+    public function removeToken(string $tokenId)
+    {
+        throw new \RuntimeException('Should not be called');
+    }
+
+    public function isTokenValid(CsrfToken $token)
+    {
+        throw new \RuntimeException('Should not be called');
+    }
+
+    public function getToken(string $tokenId)
+    {
+        return new CsrfToken('', null);
+    }
+}

--- a/Form/Type/AbstractType.php
+++ b/Form/Type/AbstractType.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\FormBundle\Form\Type;
 
+use Sulu\Bundle\FormBundle\Csrf\DisabledCsrfTokenManager;
 use Symfony\Component\Form\AbstractType as SymfonyAbstractType;
 use Symfony\Component\Form\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -60,6 +61,7 @@ abstract class AbstractType extends SymfonyAbstractType implements TypeInterface
         if ($this->csrfProtection) {
             $defaults['csrf_field_name'] = $this->csrfFieldName;
             $defaults['intention'] = $this->getDefaultIntention();
+            $defaults['csrf_token_manager'] = new DisabledCsrfTokenManager();
         }
 
         if ($this->dataClass) {

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\FormBundle\Form\Type;
 
+use Sulu\Bundle\FormBundle\Csrf\DisabledCsrfTokenManager;
 use Sulu\Bundle\FormBundle\Dynamic\Checksum;
 use Sulu\Bundle\FormBundle\Dynamic\FormFieldTypePool;
 use Sulu\Bundle\FormBundle\Entity\Dynamic;
@@ -192,6 +193,7 @@ class DynamicFormType extends AbstractType
 
         $defaults['csrf_protection'] = true;
         $defaults['csrf_field_name'] = '_token';
+        $defaults['csrf_token_manager'] = new DisabledCsrfTokenManager();
         $defaults['data_class'] = Dynamic::class;
 
         $resolver->setDefaults($defaults);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Disables the symfony CsrfManager for forms from the form-bundle.

#### Why?

Webpages with forms from the form-bundle could not be cached, because Symfony overid the public cache-control header.