### PR TITLE
Upgrade doctrine packages for prepare PHP 8 compatibility

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -42,7 +42,6 @@ jobs:
                       database: mysql
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
-                      composer-options: '--ignore-platform-reqs'
                       lint: true
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     test:
-        name: 'PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.dependency-versions }})'
+        name: 'PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.dependency-versions }}, Lint ${{ matrix.lint }})'
         runs-on: ubuntu-latest
 
         strategy:
@@ -26,6 +26,7 @@ jobs:
                           DATABASE_URL: postgres://postgres:postgres@127.0.0.1/sulu_form_test?serverVersion=12.5
                           DATABASE_CHARSET: UTF8
                           DATABASE_COLLATE:
+
                     - php-version: '7.4'
                       database: mysql
                       dependency-versions: 'highest'
@@ -34,6 +35,18 @@ jobs:
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:root@127.0.0.1/sulu_form_test?serverVersion=5.7
+                          DATABASE_CHARSET: utf8mb4
+                          DATABASE_COLLATE: utf8mb4_unicode_ci
+
+                    - php-version: '8.0'
+                      database: mysql
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
+                      composer-options: '--ignore-platform-reqs'
+                      lint: true
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                          DATABASE_URL: mysql://root:root@127.0.0.1/sulu_form_test?serverVersion=8.0
                           DATABASE_CHARSET: utf8mb4
                           DATABASE_COLLATE: utf8mb4_unicode_ci
 
@@ -71,6 +84,7 @@ jobs:
               uses: ramsey/composer-install@v1
               with:
                   dependency-versions: ${{matrix.dependency-versions}}
+                  composer-options: ${{ matrix.composer-options }}
 
             - name: Bootstrap test environment
               run: composer bootstrap-test-environment

--- a/Form/Handler.php
+++ b/Form/Handler.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\FormBundle\Form;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sulu\Bundle\FormBundle\Configuration\FormConfigurationInterface;
 use Sulu\Bundle\FormBundle\Configuration\MailConfigurationInterface;
 use Sulu\Bundle\FormBundle\Entity\Dynamic;

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/orm": "^2.5.3",
         "doctrine/persistence": "^1.3 || ^2.0",
-        "sulu/sulu": "^2.0.3 || ^2.*@dev",
+        "sulu/sulu": "^2.0.3 || 2.*@dev",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/console": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,11 @@
         }
     ],
     "require": {
-        "doctrine/orm": "^2.5.3",
         "php": "^7.2",
-        "sulu/sulu": "^2.0.3 || ^2.1@dev",
+        "doctrine/collections": "^1.0",
+        "doctrine/orm": "^2.5.3",
+        "doctrine/persistence": "^1.3 || ^2.0",
+        "sulu/sulu": "^2.0.3 || ^2.*@dev",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/console": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "doctrine/collections": "^1.0",
         "doctrine/orm": "^2.5.3",
         "doctrine/persistence": "^1.3 || ^2.0",
-        "sulu/sulu": "^2.0.3 || 2.*@dev",
+        "sulu/sulu": "^2.0.3 || 2.3@dev",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/console": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
@@ -34,7 +34,7 @@
         "twig/twig": "^1.41 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "doctrine/data-fixtures": "^1.1",
+        "doctrine/data-fixtures": "^1.3.3",
         "doctrine/doctrine-bundle": "^1.10 || ^2.0",
         "drewm/mailchimp-api": "^2.2",
         "excelwebzone/recaptcha-bundle": "^1.4.2",
@@ -42,7 +42,6 @@
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3.2",
         "massive/search-bundle": "^2.0",
-        "php-ffmpeg/php-ffmpeg": "^0.13 || ^0.14",
         "phpunit/phpunit": "^8.0",
         "symfony/browser-kit": "^4.3 || ^5.0",
         "symfony/dotenv": "^4.3 || ^5.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Upgrade doctrine packages for prepare PHP 8 compatibility.

#### Why?

Prepare compatibility to PHP 8.