### PR TITLE
Fix resubmit for cached csrf token by using esi for cacheable requests only

### DIFF
--- a/Resources/doc/csrf.md
+++ b/Resources/doc/csrf.md
@@ -21,18 +21,21 @@ behaviour of token generation or use the `@SuluForm/themes/basic.html.twig` them
 
 ## Ajax
 
-A simplified version loading the csrf token over ajax could
-look like this:
+> This solution is required when using `Varnish`:
 
 ```yaml
 # config/routes/sulu_form.yaml
 
 sulu_form.token:
-    path: /form/token
+    path: /_form/token
     defaults:
         _controller: Sulu\Bundle\FormBundle\Controller\FormTokenController::tokenAction
         _requestAnalyzer: false
 ```
+
+### A. Ajax with jquery
+
+A simplified version loading the csrf token over ajax could look like this:
 
 ```twig
 # your-theme.html.twig
@@ -48,7 +51,50 @@ sulu_form.token:
 ```
 
 ```js
-jQuery.get('/form/token?form=' + formName + '&html=0').done(function(data) {
+jQuery.get('/_form/token?form=' + formName + '&html=0').done(function(data) {
     jQuery('#' + fieldId).val(data);
 });
+```
+
+### B. Ajax with sulu web js
+
+When using [`@sulu/web`](https://github.com/sulu/web-js) / [`sulu/web-twig`](https://github.com/sulu/web-twig) component library this could look like the following:
+
+```twig
+{# templates/form/your-theme.html.twig #}
+
+{% extends '@SuluForm/themes/basic.html.twig' %}
+
+{%- block csrf_token_widget -%}
+    {{ block('hidden_widget') }}
+
+    {% do register_component('csrf-token', { id: id, fornName: form.parent.vars.name }) %}
+{% endblock %}
+```
+
+```js
+// assets/website/js/componenes/csrf-token.js
+
+export default class CsrfToken {
+    initialize(el, options) {
+        fetch('/_form/token?form=' + options.formName + '&html=0').then((response) => {
+            if (!response.ok) {
+                return Promise.reject(response);
+            }
+
+            return response.text();
+        }).then((data) => {
+            el.value = data;
+        });
+    }
+}
+```
+
+```js
+// assets/website/js/main.js
+
+import web from '@sulu/web';
+import CsrfToken from './components/csrf-token';
+
+web.registerComponent('csrf-token', CsrfToken);
 ```

--- a/Resources/doc/csrf.md
+++ b/Resources/doc/csrf.md
@@ -21,7 +21,7 @@ behaviour of token generation or use the `@SuluForm/themes/basic.html.twig` them
 
 ## Ajax
 
-> This solution is required when using `Varnish`:
+> This solution is required when pages are cached using `Varnish`:
 
 ```yaml
 # config/routes/sulu_form.yaml
@@ -35,7 +35,7 @@ sulu_form.token:
 
 ### A. Ajax with jquery
 
-A simplified version loading the csrf token over ajax could look like this:
+A simple example for loading the csrf token over ajax looks like this:
 
 ```twig
 # your-theme.html.twig
@@ -56,9 +56,9 @@ jQuery.get('/_form/token?form=' + formName + '&html=0').done(function(data) {
 });
 ```
 
-### B. Ajax with sulu web js
+### B. Ajax with sulu web-js
 
-When using [`@sulu/web`](https://github.com/sulu/web-js) / [`sulu/web-twig`](https://github.com/sulu/web-twig) component library this could look like the following:
+When using [`@sulu/web`](https://github.com/sulu/web-js) / [`sulu/web-twig`](https://github.com/sulu/web-twig) component library, loading the csrf token over ajax looks like this:
 
 ```twig
 {# templates/form/your-theme.html.twig #}
@@ -68,7 +68,7 @@ When using [`@sulu/web`](https://github.com/sulu/web-js) / [`sulu/web-twig`](htt
 {%- block csrf_token_widget -%}
     {{ block('hidden_widget') }}
 
-    {% do register_component('csrf-token', { id: id, fornName: form.parent.vars.name }) %}
+    {% do register_component('csrf-token', { id: id, formName: form.parent.vars.name }) %}
 {% endblock %}
 ```
 

--- a/Resources/views/themes/basic.html.twig
+++ b/Resources/views/themes/basic.html.twig
@@ -19,13 +19,23 @@
     {%- endif -%}
 {%- endblock form_label -%}
 
-{# CSRF Token over ESI #}
+{# CSRF Token #}
 {%- block csrf_token_widget %}
-    {{ render_esi(controller('Sulu\\Bundle\\FormBundle\\Controller\\FormTokenController::tokenAction', {
+    {% set controller = controller('Sulu\\Bundle\\FormBundle\\Controller\\FormTokenController::tokenAction', {
         'form': form.parent.vars.name,
         'html': true,
-        _requestAnalyzer: false }))
-    }}
+        _requestAnalyzer: false
+    }) %}
+
+    {#
+        for cacheable pages we need to load the csrf token over esi
+        for the post request we can directly render it
+    #}
+    {% if app.request.isMethodCacheable %}
+        {{ render_esi(controller) }}
+    {% else %}
+        {{ render(controller) }}
+    {% endif %}
 {%- endblock csrf_token_widget -%}
 
 {# Headline #}

--- a/Resources/views/themes/basic.html.twig
+++ b/Resources/views/themes/basic.html.twig
@@ -28,8 +28,8 @@
     }) %}
 
     {#
-        for cacheable pages we need to load the csrf token over esi
-        for the post request we can directly render it
+        If a request is cacheable, the CSRF token must be loaded over ESI to allow for caching the response.
+        If a request is not cacheable (eg. POST request), we can directly render it.
     #}
     {% if app.request.isMethodCacheable %}
         {{ render_esi(controller) }}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Do a `render_esi` only when its a cacheable request. 

#### Why?

This avoids that an additional ESI request is needed when a uncached request is done via `POST`. This also fixes a problem that a when you get a `CSRF Token invalid` message on varnish when it was not configured that it should be loaded over JS.
