### PR TITLE
Add ability to define landing page when form is submitted successfully

### DIFF
--- a/Configuration/FormConfiguration.php
+++ b/Configuration/FormConfiguration.php
@@ -37,6 +37,11 @@ class FormConfiguration implements FormConfigurationInterface
     private $fileSave = true;
 
     /**
+     * @var string|null
+     */
+    private ?string $successRedirect = null;
+
+    /**
      * @var MailConfigurationInterface
      */
     private $adminMailConfiguration;
@@ -145,6 +150,18 @@ class FormConfiguration implements FormConfigurationInterface
     public function setSave(bool $save): self
     {
         $this->save = $save;
+
+        return $this;
+    }
+
+    public function getSuccessRedirect(): ?string
+    {
+        return $this->successRedirect;
+    }
+
+    public function setSuccessRedirect(?string $successRedirect): self
+    {
+        $this->successRedirect = $successRedirect;
 
         return $this;
     }

--- a/Configuration/FormConfigurationFactory.php
+++ b/Configuration/FormConfigurationFactory.php
@@ -71,6 +71,7 @@ class FormConfigurationFactory
         $config = $this->create($locale);
         $config->setFileFields($this->getFileFieldsByDynamic($dynamic));
         $config->setFileSave(!$translation->getDeactivateAttachmentSave());
+        $config->setSuccessRedirect($translation->getTargetSuccess());
 
         $adminMailConfiguration = $this->buildAdminMailConfigurationByDynamic($dynamic);
         $websiteMailConfiguration = $this->buildWebsiteMailConfigurationByDynamic($dynamic);

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -327,6 +327,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
                 'toName' => $translation->getToName(),
                 'subject' => $translation->getSubject(),
                 'mailText' => $translation->getMailText(),
+                'targetSuccess' => $translation->getTargetSuccess(),
                 'submitLabel' => $translation->getSubmitLabel(),
                 'successText' => $translation->getSuccessText(),
                 'sendAttachments' => $translation->getSendAttachments(),

--- a/Entity/Form.php
+++ b/Entity/Form.php
@@ -228,6 +228,7 @@ class Form
             'title' => $translation->getTitle(),
             'subject' => $translation->getSubject(),
             'mailText' => $translation->getMailText(),
+            'targetSuccess' => $translation->getTargetSuccess(),
             'submitLabel' => $translation->getSubmitLabel(),
             'successText' => $translation->getSuccessText(),
             'fromEmail' => $translation->getFromEmail(),

--- a/Entity/FormTranslation.php
+++ b/Entity/FormTranslation.php
@@ -61,6 +61,11 @@ class FormTranslation implements AuditableInterface
     /**
      * @var null|string
      */
+    private $targetSuccess;
+
+    /**
+     * @var null|string
+     */
     private $submitLabel;
 
     /**
@@ -200,6 +205,18 @@ class FormTranslation implements AuditableInterface
     public function getMailText(): ?string
     {
         return $this->mailText;
+    }
+
+    public function getTargetSuccess(): ?string
+    {
+        return $this->targetSuccess;
+    }
+
+    public function setTargetSuccess(?string $targetSuccess): self
+    {
+        $this->targetSuccess = $targetSuccess;
+
+        return $this;
     }
 
     public function setSubmitLabel(?string $submitLabel): self

--- a/Event/RequestListener.php
+++ b/Event/RequestListener.php
@@ -92,7 +92,12 @@ class RequestListener
             $dynFormSavedEvent = new DynFormSavedEvent($serializedObject, $dynamic);
             $this->eventDispatcher->dispatch($dynFormSavedEvent, DynFormSavedEvent::NAME);
 
-            $response = new RedirectResponse('?send=true');
+            if ($form->get('targetSuccess') && !empty($form->get('targetSuccess')->getData())) {
+                $response = new RedirectResponse($form->get('targetSuccess')->getData());
+            } else {
+                $response = new RedirectResponse('?send=true');
+            }
+
             $event->setResponse($response);
         }
     }

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\FormBundle\Dynamic\FormFieldTypePool;
 use Sulu\Bundle\FormBundle\Entity\Dynamic;
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;
+use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -42,16 +43,23 @@ class DynamicFormType extends AbstractType
     private $honeyPotField;
 
     /**
+     * @var ContentMapperInterface
+     */
+    private $contentMapper;
+
+    /**
      * DynamicFormType constructor.
      */
     public function __construct(
         FormFieldTypePool $typePool,
         Checksum $checksum,
+        ContentMapperInterface $contentMapper,
         ?string $honeyPotField = null
     ) {
         $this->typePool = $typePool;
         $this->checksum = $checksum;
         $this->honeyPotField = $honeyPotField;
+        $this->contentMapper = $contentMapper;
     }
 
     /**
@@ -165,6 +173,20 @@ class DynamicFormType extends AbstractType
                     'required' => false,
                 ]
             );
+        }
+
+        // Redirect URL after success
+        if ($translation->getTargetSuccess()) {
+            $contentStructure = $this->contentMapper->load(
+                $translation->getTargetSuccess(),
+                $builder->getData()->getWebspaceKey(),
+                $locale
+            );
+
+            $builder->add('targetSuccess', HiddenType::class, [
+                'data' => $contentStructure->getPath(),
+                'mapped' => false,
+            ]);
         }
 
         // Add submit button.

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -89,6 +89,7 @@ class FormManager
         $translation->setToEmail(self::getValue($data, 'toEmail'));
         $translation->setToName(self::getValue($data, 'toName'));
         $translation->setMailText(self::getValue($data, 'mailText'));
+        $translation->setTargetSuccess(self::getValue($data, 'targetSuccess'));
         $translation->setSubmitLabel(self::getValue($data, 'submitLabel'));
         $translation->setSuccessText(self::getValue($data, 'successText'));
         $translation->setSendAttachments(self::getValue($data, 'sendAttachments', false));

--- a/Resources/config/doctrine/FormTranslation.orm.xml
+++ b/Resources/config/doctrine/FormTranslation.orm.xml
@@ -16,6 +16,7 @@
         <field name="toEmail" column="toEmail" type="string" length="255" nullable="true"/>
         <field name="toName" column="toName" type="string" length="255" nullable="true"/>
         <field name="mailText" column="mailText" type="text" nullable="true"/>
+        <field name="targetSuccess" column="targetSuccess" type="string" nullable="true"/>
         <field name="submitLabel" column="submitLabel" type="string" nullable="true"/>
         <field name="successText" column="successText" type="text" nullable="true"/>
         <field name="sendAttachments" column="sendAttachments" type="boolean" nullable="false">

--- a/Resources/config/forms/form_details.xml
+++ b/Resources/config/forms/form_details.xml
@@ -22,6 +22,12 @@
             </meta>
 
             <properties>
+                <property name="targetSuccess" type="single_page_selection">
+                    <meta>
+                        <title lang="en">sulu_form.success_landing_page</title>
+                    </meta>
+                </property>
+
                 <property name="submitLabel" type="text_line">
                     <meta>
                         <title>sulu_form.submit_label</title>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -97,6 +97,7 @@
         <service id="sulu_form.form_type" class="Sulu\Bundle\FormBundle\Form\Type\DynamicFormType">
             <argument type="service" id="sulu_form.dynamic.form_field_type_pool" />
             <argument type="service" id="sulu_form.checksum" />
+            <argument type="service" id="sulu.content.mapper"/>
             <argument>%sulu_form.honeypot_field%</argument>
 
             <tag name="form.type"/>
@@ -175,8 +176,8 @@
 
         <!-- Properties XML Loader -->
         <service
-                id="sulu_form.metadata.properties_xml_loader"
-                class="Sulu\Bundle\FormBundle\Metadata\PropertiesXmlLoader"
+            id="sulu_form.metadata.properties_xml_loader"
+            class="Sulu\Bundle\FormBundle\Metadata\PropertiesXmlLoader"
         >
             <argument type="service" id="sulu_page.structure.properties_xml_parser"/>
         </service>
@@ -231,8 +232,8 @@
 
         <!-- Form Website Controller -->
         <service id="sulu_form.form_website_controller"
-            class="Sulu\Bundle\FormBundle\Controller\FormWebsiteController"
-            public="true">
+                 class="Sulu\Bundle\FormBundle\Controller\FormWebsiteController"
+                 public="true">
             <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />
             <tag name="sulu.context" context="website"/>

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -79,5 +79,6 @@
   "sulu_form.salutation_mr": "Mr.",
   "sulu_form.salutation_ms": "Ms.",
   "sulu_form.single_form_selection.no_form_selected": "No form selected",
-  "sulu_form.single_form_selection.overlay_title": "Select a form"
+  "sulu_form.single_form_selection.overlay_title": "Select a form",
+  "sulu_form.success_landing_page": "Success landing page"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #44
| License | MIT

#### What's in this PR?

Add the ability to define a custom landing page after a form was submitted successfully.

This is my first PR for a feature like this, so I'm not sure if I'm on the right track or whether this should be handled completely differently, so feel free to tear this down if needed... 😄 

#### To Do

- [ ] Create documentation
- [ ] Also provide a field to add a custom querystring to the landing page URL
- [ ] Tests (?)
