### PR TITLE
Add protected media collection setting for form system collections

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,10 +35,28 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('mailchimp_subscribe_status')->defaultValue('subscribed')->end()
             ->enumNode('media_collection_strategy')
                 ->values([
+                    null,
                     SuluFormExtension::MEDIA_COLLECTION_STRATEGY_SINGLE,
                     SuluFormExtension::MEDIA_COLLECTION_STRATEGY_TREE,
                 ])
-                ->defaultValue(SuluFormExtension::MEDIA_COLLECTION_STRATEGY_SINGLE)
+                ->defaultValue(null)
+                ->setDeprecated()
+            ->end()
+            ->arrayNode('media')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->booleanNode('protected')
+                        ->info('Enables the media protection so media are only downloadable from the admin.')
+                        ->defaultValue(false)
+                    ->end()
+                    ->enumNode('collection_strategy')
+                        ->values([
+                            SuluFormExtension::MEDIA_COLLECTION_STRATEGY_SINGLE,
+                            SuluFormExtension::MEDIA_COLLECTION_STRATEGY_TREE,
+                        ])
+                        ->defaultValue(SuluFormExtension::MEDIA_COLLECTION_STRATEGY_SINGLE)
+                    ->end()
+                ->end()
             ->end()
             ->arrayNode('static_forms')
                 ->useAttributeAsKey('name')

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -133,6 +133,8 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        $mediaCollectionStrategy = $config['media_collection_strategy'] ? $config['media_collection_strategy'] : $config['media']['collection_strategy'];
+
         $container->setParameter('sulu_form.mail.from', $config['mail']['from']);
         $container->setParameter('sulu_form.mail.to', $config['mail']['to']);
         $container->setParameter('sulu_form.mail.sender', $config['mail']['sender']);
@@ -146,14 +148,14 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_form.mailchimp_api_key', $config['mailchimp_api_key']);
         $container->setParameter('sulu_form.mailchimp_subscribe_status', $config['mailchimp_subscribe_status']);
         $container->setParameter('sulu_form.dynamic_lists.config', $config['dynamic_lists']);
-        $container->setParameter('sulu_form.media_collection_strategy', $config['media_collection_strategy']);
+        $container->setParameter('sulu_form.media_collection_strategy', $mediaCollectionStrategy);
         $container->setParameter('sulu_form.static_forms', $config['static_forms']);
         $container->setParameter('sulu_form.dynamic_disabled_types', $config['dynamic_disabled_types']);
 
         // Default Media Collection Strategy
         $container->setAlias(
             'sulu_form.media_collection_strategy.default',
-            'sulu_form.media_collection_strategy.' . $config['media_collection_strategy']
+            'sulu_form.media_collection_strategy.' . $mediaCollectionStrategy
         );
 
         // Dynamic List Builder
@@ -206,6 +208,10 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
                 ->setPublic(true);
             $container->setAlias(FormTokenController::class, 'sulu_form.form_token_controller')
                 ->setPublic(true);
+        }
+
+        if ($config['media']['protected']) {
+            $loader->load('protected_media.xml');
         }
     }
 }

--- a/Event/ProtectedMediaSubscriber.php
+++ b/Event/ProtectedMediaSubscriber.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Event;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @internal
+ */
+class ProtectedMediaSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var FormatCacheInterface
+     */
+    private $formatCache;
+
+    /**
+     * @var string[]
+     */
+    protected $protectedCollectionKeys = [];
+
+    /**
+     * @param string[] $protectedCollectionKeys
+     */
+    public function __construct(
+        UrlGeneratorInterface $urlGenerator,
+        EntityManagerInterface $entityManager,
+        FormatCacheInterface $formatCache,
+        array $protectedCollectionKeys = [
+            'sulu_form',
+        ]
+    ) {
+        $this->urlGenerator = $urlGenerator;
+        $this->entityManager = $entityManager;
+        $this->formatCache = $formatCache;
+        $this->protectedCollectionKeys = $protectedCollectionKeys;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            'kernel.request' => 'onRequest',
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        $routeName = $request->attributes->get('_route');
+
+        $mediaId = null;
+
+        if ('sulu_media.website.image.proxy' === $routeName) {
+            $slug = $request->attributes->get('slug');
+            if (!$slug) {
+                return;
+            }
+
+            $mediaProperties = $this->formatCache->analyzedMediaUrl($request->getPathInfo());
+            $mediaId = $mediaProperties['id'];
+        }
+
+        if (!$mediaId) {
+            /** @var string|null $mediaId */
+            $mediaId = $request->attributes->get('id');
+        }
+
+        if (!\is_numeric($mediaId) || !$this->isProtectedCollection((int) $mediaId)) {
+            return;
+        }
+
+        if ('sulu_media.website.image.proxy' === $routeName) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $url = $this->urlGenerator->generate(
+            'sulu_media.website.media.download_admin',
+            \array_merge(
+                $request->query->all(),
+                $request->attributes->get('_route_params')
+            )
+        );
+
+        $event->setResponse(new RedirectResponse($url));
+    }
+
+    private function isProtectedCollection(int $mediaId): bool
+    {
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->from(MediaInterface::class, 'media')
+            ->innerJoin('media.collection', 'collection')
+            ->select('collection.key')
+            ->where('media.id = :id')
+            ->setParameter('id', $mediaId);
+
+        $collectionKey = $queryBuilder->getQuery()->getSingleScalarResult();
+
+        foreach ($this->protectedCollectionKeys as $protectedCollectionKey) {
+            if (0 === \strpos($collectionKey, $protectedCollectionKey)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Resources/config/protected_media.xml
+++ b/Resources/config/protected_media.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Article Title Provider -->
+        <service id="sulu_form.private_media_subscriber" class="Sulu\Bundle\FormBundle\Event\ProtectedMediaSubscriber">
+            <argument type="service" id="router"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="sulu_media.format_cache"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+    </services>
+</container>

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -223,7 +223,20 @@ To create for every form and page an own collection you need to configure the fo
 
 ```yml
 sulu_form:
-    media_collection_strategy: "tree"
+    media:
+        collection_strategy: "tree"
+```
+
+## Media Protection
+
+In some cases you want that the uploaded media is only download able from the admin context in all cases.
+To force this you need to log into to enabled media protection with, this should be enabled by default in
+since 2.2 over the form bundle recipe:
+
+```yml
+sulu_form:
+    media:
+        protected: true
 ```
 
 ## Test Checklist

--- a/Tests/Unit/Event/ProtectedMediaSubscriberTest.php
+++ b/Tests/Unit/Event/ProtectedMediaSubscriberTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Tests\Unit\Event;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\FormBundle\Event\ProtectedMediaSubscriber;
+use Sulu\Bundle\FormBundle\Tests\Application\Kernel;
+use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
+use Sulu\Component\HttpKernel\SuluKernel;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ProtectedMediaSubscriberTest extends TestCase
+{
+    /**
+     * @var EntityManagerInterface|ObjectProphecy
+     */
+    private $entityManager;
+
+    /**
+     * @var FormatCacheInterface|ObjectProphecy
+     */
+    private $formatCache;
+
+    /**
+     * @var UrlGeneratorInterface|ObjectProphecy
+     */
+    private $urlGenerator;
+
+    /**
+     * @var ProtectedMediaSubscriber
+     */
+    private $protectedMediaSubscriber;
+
+    public function setUp(): void
+    {
+        $this->urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $this->formatCache = $this->prophesize(FormatCacheInterface::class);
+
+        $this->protectedMediaSubscriber = new ProtectedMediaSubscriber(
+            $this->urlGenerator->reveal(),
+            $this->entityManager->reveal(),
+            $this->formatCache->reveal()
+        );
+    }
+
+    public function testNoMasterRequest(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'other');
+
+        $event = new RequestEvent(
+            new Kernel('test', true, SuluKernel::CONTEXT_WEBSITE),
+            $request,
+            HttpKernelInterface::SUB_REQUEST
+        );
+
+        $this->formatCache->analyzedMediaUrl(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->protectedMediaSubscriber->onRequest($event);
+    }
+
+    public function testOtherRoute(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'other');
+
+        $event = new RequestEvent(
+            new Kernel('test', true, SuluKernel::CONTEXT_WEBSITE),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $this->formatCache->analyzedMediaUrl(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->protectedMediaSubscriber->onRequest($event);
+    }
+
+    public function testImageProxyRoute(): void
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'sulu_media.website.image.proxy');
+        $request->server->set('REQUEST_URI', '/uploads/media/50x50/2-test-image.jpg');
+        $request->attributes->set('slug', '/50x50/2-test-image.jpg');
+
+        $event = new RequestEvent(
+            new Kernel('test', true, SuluKernel::CONTEXT_WEBSITE),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $this->formatCache->analyzedMediaUrl(Argument::any())
+            ->willReturn([
+                'id' => 1,
+                'format' => '50x50',
+                'fileName' => 'test-image',
+            ])
+            ->shouldBeCalled();
+
+        $this->mockLoadCollectionKey('sulu_form');
+
+        $this->protectedMediaSubscriber->onRequest($event);
+    }
+
+    public function testDownloadRoute(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'sulu_media.website.image.download');
+        $request->server->set('REQUEST_URI', '/media/2/download/test-image.jpg');
+        $request->attributes->set('id', '2');
+        $request->attributes->set('_route_params', ['id' => '2', 'slug' => 'test-image.jpg']);
+        $request->query->set('v', '3');
+
+        $event = new RequestEvent(
+            new Kernel('test', true, SuluKernel::CONTEXT_WEBSITE),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $this->mockLoadCollectionKey('sulu_form');
+
+        $this->urlGenerator->generate(
+            'sulu_media.website.media.download_admin',
+            [
+                'id' => '2',
+                'slug' => 'test-image.jpg',
+                'v' => '3',
+            ]
+        )->shouldBeCalled()
+            ->willReturn('/admin/media/2/download/test-image.jpg');
+
+        $this->protectedMediaSubscriber->onRequest($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/admin/media/2/download/test-image.jpg', $response->getTargetUrl());
+    }
+
+    private function mockLoadCollectionKey(string $collectionKey): void
+    {
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $this->entityManager->createQueryBuilder()
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalled();
+        $queryBuilder->from(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalled();
+        $queryBuilder->innerJoin(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalled();
+        $queryBuilder->where(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalled();
+        $queryBuilder->select(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalled();
+        $queryBuilder->setParameter(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $query = new class($collectionKey) {
+            /** @var string string */
+            private $collectionKey;
+
+            public function __construct(string $collectionKey)
+            {
+                $this->collectionKey = $collectionKey;
+            }
+
+            public function getSingleScalarResult(): string
+            {
+                return $this->collectionKey;
+            }
+        };
+
+        $queryBuilder->getQuery()
+            ->willReturn($query)
+            ->shouldBeCalled();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/orm": "^2.5.3",
         "doctrine/persistence": "^1.3 || ^2.0",
-        "sulu/sulu": "^2.0.3 || 2.3@dev",
+        "sulu/sulu": "^2.2.0 || 2.3@dev",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/console": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Add protected form collection setting.

#### Why?

In some cases you want that the uploaded media is only download able from the admin context in all cases.

#### Example Usage

```yml
sulu_form:
    media:
        protected: true
```

1. Create form with media (e.g.: `bin/console sulu:form:generate-form`)
2. Submit a media
3. Try to download the media you should be redirect to the admin url which will download the media only when you are logged in

#### Todo

 - [x] Create 2.2 Form Bundle registry recipe with this option enabled