### PR TITLE
EventListener only for download routes

### DIFF
--- a/Event/ProtectedMediaSubscriber.php
+++ b/Event/ProtectedMediaSubscriber.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\FormBundle\Event;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NoResultException;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/Event/ProtectedMediaSubscriber.php
+++ b/Event/ProtectedMediaSubscriber.php
@@ -82,10 +82,17 @@ class ProtectedMediaSubscriber implements EventSubscriberInterface
 
         $routeName = $request->attributes->get('_route');
 
+        if ('sulu_media.website.image.proxy' !== $routeName
+            && 'sulu_media.website.media.download' !== $routeName
+        ) {
+            return;
+        }
+
         $mediaId = null;
 
         if ('sulu_media.website.image.proxy' === $routeName) {
             $slug = $request->attributes->get('slug');
+
             if (!$slug) {
                 return;
             }
@@ -127,7 +134,11 @@ class ProtectedMediaSubscriber implements EventSubscriberInterface
             ->where('media.id = :id')
             ->setParameter('id', $mediaId);
 
-        $collectionKey = $queryBuilder->getQuery()->getSingleScalarResult();
+        try {
+            $collectionKey = $queryBuilder->getQuery()->getSingleScalarResult();
+        } catch (NoResultException $e) {
+            return false;
+        }
 
         foreach ($this->protectedCollectionKeys as $protectedCollectionKey) {
             if (0 === \strpos($collectionKey, $protectedCollectionKey)) {

--- a/Tests/Unit/Event/ProtectedMediaSubscriberTest.php
+++ b/Tests/Unit/Event/ProtectedMediaSubscriberTest.php
@@ -127,7 +127,7 @@ class ProtectedMediaSubscriberTest extends TestCase
     public function testDownloadRoute(): void
     {
         $request = new Request();
-        $request->attributes->set('_route', 'sulu_media.website.image.download');
+        $request->attributes->set('_route', 'sulu_media.website.media.download');
         $request->server->set('REQUEST_URI', '/media/2/download/test-image.jpg');
         $request->attributes->set('id', '2');
         $request->attributes->set('_route_params', ['id' => '2', 'slug' => 'test-image.jpg']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixed that the event-listener is just executed for media routes.

#### Why?

It also reacted on the get_contact route for example which caused errors.

