### PR TITLE
Fix csrf token symfony 4 php 7.2 compatibility

### DIFF
--- a/Csrf/DisabledCsrfTokenManager.php
+++ b/Csrf/DisabledCsrfTokenManager.php
@@ -26,12 +26,18 @@ class DisabledCsrfTokenManager implements CsrfTokenManagerInterface
         $this->csrfTokenManager = $csrfTokenManager;
     }
 
-    public function refreshToken(string $tokenId)
+    /**
+     * @param string $tokenId
+     */
+    public function refreshToken($tokenId)
     {
         return $this->csrfTokenManager->refreshToken($tokenId);
     }
 
-    public function removeToken(string $tokenId)
+    /**
+     * @param string $tokenId
+     */
+    public function removeToken($tokenId)
     {
         return $this->csrfTokenManager->removeToken($tokenId);
     }
@@ -41,7 +47,10 @@ class DisabledCsrfTokenManager implements CsrfTokenManagerInterface
         return $this->csrfTokenManager->isTokenValid($token);
     }
 
-    public function getToken(string $tokenId)
+    /**
+     * @param string $tokenId
+     */
+    public function getToken($tokenId)
     {
         return new CsrfToken('', null);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

The `string` typehints only exist in Symfony 5 for this interface so they need to be removed.

#### Why?

See https://github.com/sulu/SuluFormBundle/runs/2701155587?check_suite_focus=true