### PR TITLE
Add Phone Number Validation

### DIFF
--- a/PhoneType.php
+++ b/PhoneType.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Dynamic\Types;
+
+use Sulu\Bundle\FormBundle\Dynamic\FormFieldTypeConfiguration;
+use Sulu\Bundle\FormBundle\Dynamic\FormFieldTypeInterface;
+use Sulu\Bundle\FormBundle\Entity\FormField;
+use Symfony\Component\Form\Extension\Core\Type\TelType as TypeTelType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * The Phone form field type.
+ */
+class PhoneType implements FormFieldTypeInterface
+{
+    use SimpleTypeTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): FormFieldTypeConfiguration
+    {
+        return new FormFieldTypeConfiguration(
+            'sulu_form.type.phone',
+            __DIR__ . '/../../Resources/config/form-fields/field_example_default.xml'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(FormBuilderInterface $builder, FormField $field, string $locale, array $options): void
+    {
+        $options['constraints'] = [new Callback(function($object, ExecutionContextInterface $context, $payload) {
+
+            $exception = false;
+
+            $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
+            try {
+                $swissNumberProto = $phoneUtil->parse($object, "DE");
+                $exception = !$phoneUtil->isValidNumber($swissNumberProto);
+
+            } catch (\libphonenumber\NumberParseException $e) {
+                $exception = true;
+            }
+
+            if ($exception) {
+                $context->buildViolation('Invalid phone number')
+                    ->addViolation()
+                ;
+            }
+        })];
+        $type = TypeTelType::class;
+        $builder
+            ->add($field->getKey(), $type, $options);
+    }
+}


### PR DESCRIPTION
create phone number validation

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Phone number validation for Phone Typ field

#### Why?

it doesnt exist an phone number validation. 

#### Example Usage

```php
// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)

public function build(FormBuilderInterface $builder, FormField $field, string $locale, array $options): void
    {
        $options['constraints'] = [new Callback(function($object, ExecutionContextInterface $context, $payload) {

            $exception = false;

            $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
            try {
                $phoneNumber = $phoneUtil->parse($object, "DE");
                $exception = !$phoneUtil->isValidNumber($phoneNumber);

            } catch (\libphonenumber\NumberParseException $e) {
                $exception = true;
            }

            if ($exception) {
                $context->buildViolation('Invalid phone number')
                    ->addViolation()
                ;
            }
        })];
        $type = TypeTelType::class;
        $builder
            ->add($field->getKey(), $type, $options);
    }

```

#### To Do

- [ ] Create documentation
