### PR TITLE
Improve documentation about TestFrom creation

### DIFF
--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -67,11 +67,13 @@ one of the dynamic templates which can be created in the Sulu backend.
 
 Use `article` as `resourceKey` when you use the single_form_selection inside article template.
 
-To generate a basic form use the following command:
+You can create a basic form called: `Test Form` which include all usable form types with:
 
 ```bash
 php bin/adminconsole sulu:form:generate-form
 ```
+
+> If a form called: `Test Form` already exist, it will be updated. 
 
 ## Output Form and customize
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Update the documentation about the TestForm creation

#### Why?

Currently, documentation tell that to CREATE A FORM, we should run this command, this is totally wrong, it will just create / update a form called `TestForm`. Which is not the same thing.

With the current documentation, we expect to have such a "interactive builder" of a form like the make:entity from SYmfony