### PR TITLE
Add a confirmation message for generate-form command

### DIFF
--- a/Command/FormGeneratorCommand.php
+++ b/Command/FormGeneratorCommand.php
@@ -221,6 +221,8 @@ class FormGeneratorCommand extends Command
         $this->entityManager->persist($form);
         $this->entityManager->flush();
 
+        $output->writeln('A form called "Test Form" has been successfully created/updated.');
+
         return 0;
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

We just print a confirmation message to developper to confirm them the Test Form has been created.

#### Why?

We cannot understand what happen here.

```
root@933afbf8817a:/var/www/html# php bin/adminconsole sulu:form:generate-form    
root@933afbf8817a:/var/www/html# 
```



#### Example Usage

Now, we have an output 👍 

```
root@933afbf8817a:/var/www/html# php bin/adminconsole sulu:form:generate-form    
A Form called `Test Form` has been successfully created/updated.
root@933afbf8817a:/var/www/html# 
```
#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)
