### PR TITLE
Add example and default value to radio buttons

### DIFF
--- a/Dynamic/Types/ChoiceTrait.php
+++ b/Dynamic/Types/ChoiceTrait.php
@@ -39,8 +39,6 @@ trait ChoiceTrait
         FormFieldTranslation $translation,
         array $options
     ): array {
-        $options['placeholder'] = false;
-
         if (isset($options['attr']['placeholder'])) {
             $options['placeholder'] = $options['attr']['placeholder'];
             unset($options['attr']['placeholder']);

--- a/Dynamic/Types/ChoiceTrait.php
+++ b/Dynamic/Types/ChoiceTrait.php
@@ -39,6 +39,8 @@ trait ChoiceTrait
         FormFieldTranslation $translation,
         array $options
     ): array {
+        $options['placeholder'] = false;
+
         if (isset($options['attr']['placeholder'])) {
             $options['placeholder'] = $options['attr']['placeholder'];
             unset($options['attr']['placeholder']);

--- a/Resources/config/form-fields/field_choices.xml
+++ b/Resources/config/form-fields/field_choices.xml
@@ -4,6 +4,16 @@
             xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/properties-1.0.xsd">
     <xi:include href="default_field.xml"  xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
                       xpointer(//sulu:property)"/>
+    <property name="placeholder" type="text_line" colspan="6">
+        <meta>
+            <title>sulu_form.example</title>
+        </meta>
+    </property>
+    <property name="defaultValue" type="text_line" colspan="6">
+        <meta>
+            <title>sulu_form.default</title>
+        </meta>
+    </property>
     <property name="options/choices" type="text_area">
         <meta>
             <title>sulu_form.choice</title>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| License | MIT

#### What's in this PR?

Content managers can add a default value and a placeholder for radiobuttons.

#### Why?

If nothing is set there is a "None" value shown as default.

#### Example Usage

Create a new form with radio buttons.

#### BC Breaks/Deprecations

~~Existing "None" selections will dissapear.~~ EDIT: this is expected and can be avoided by the content manager when selecting `Required` on the radio buttons, or any other choice.
