### PR TITLE
Fix declaration incompatible error with symfony 6

### DIFF
--- a/Csrf/DisabledCsrfTokenManager.php
+++ b/Csrf/DisabledCsrfTokenManager.php
@@ -29,7 +29,7 @@ class DisabledCsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * @param string $tokenId
      */
-    public function refreshToken($tokenId)
+    public function refreshToken($tokenId): CsrfToken
     {
         return $this->csrfTokenManager->refreshToken($tokenId);
     }
@@ -37,12 +37,12 @@ class DisabledCsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * @param string $tokenId
      */
-    public function removeToken($tokenId)
+    public function removeToken($tokenId): ?string
     {
         return $this->csrfTokenManager->removeToken($tokenId);
     }
 
-    public function isTokenValid(CsrfToken $token)
+    public function isTokenValid(CsrfToken $token): bool
     {
         return $this->csrfTokenManager->isTokenValid($token);
     }

--- a/Csrf/DisabledCsrfTokenManager.php
+++ b/Csrf/DisabledCsrfTokenManager.php
@@ -50,7 +50,7 @@ class DisabledCsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * @param string $tokenId
      */
-    public function getToken($tokenId)
+    public function getToken($tokenId): CsrfToken
     {
         return new CsrfToken('', null);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix declaration incompatible error with symfony 6

#### Why?

```
Compile Error: Declaration of Sulu\Bundle\FormBundle\Csrf\DisabledCsrfTokenManager::getToken($tokenId) must be compatible with Symfony\Component\Security\Csrf\CsrfTokenManagerInterface::getToken(string $tokenId): Symfony\Component\Security\Csrf\CsrfToken
```