### PR TITLE
Add toolbar action for creating copy of current form to edit view

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -100,11 +100,11 @@ jobs:
               run: composer bootstrap-test-environment
               env: ${{ matrix.env }}
 
+            - name: Execute test cases
+              run: time composer test
+              env: ${{ matrix.env }}
+
             - name: Lint code
               if: ${{ matrix.lint }}
               run: composer lint
-              env: ${{ matrix.env }}
-
-            - name: Execute test cases
-              run: time composer test
               env: ${{ matrix.env }}

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -42,7 +42,7 @@ jobs:
                       database: mysql
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
-                      lint: true
+                      lint: false
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:root@127.0.0.1/sulu_form_test?serverVersion=5.7
@@ -53,7 +53,7 @@ jobs:
                       database: mysql
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
-                      lint: false
+                      lint: true
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:root@127.0.0.1/sulu_form_test?serverVersion=5.7
@@ -108,4 +108,3 @@ jobs:
             - name: Execute test cases
               run: time composer test
               env: ${{ matrix.env }}
-

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,10 +10,11 @@ with this source code in the file LICENSE.
 EOF;
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude(['var/cache'])
+    ->exclude(['var/cache', 'node_modules'])
     ->in(__DIR__);
 
-return PhpCsFixer\Config::create()
+$config = new PhpCsFixer\Config();
+$config->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -21,8 +22,16 @@ return PhpCsFixer\Config::create()
         'concat_space' => ['spacing' => 'one'],
         'function_declaration' => ['closure_function_spacing' => 'none'],
         'header_comment' => ['header' => $header],
+        'native_constant_invocation' => true,
+        'native_function_casing' => true,
+        'native_function_invocation' => ['include' => ['@internal']],
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
         'ordered_imports' => true,
         'phpdoc_align' => ['align' => 'left'],
         'phpdoc_types_order' => false,
+        'single_line_throw' => false,
+        'single_line_comment_spacing' => false,
     ])
     ->setFinder($finder);
+
+return $config;

--- a/Admin/FormAdmin.php
+++ b/Admin/FormAdmin.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\FormBundle\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -90,6 +91,13 @@ class FormAdmin extends Admin
         $formToolbarActions = [
             new ToolbarAction('sulu_admin.save'),
             new ToolbarAction('sulu_admin.delete'),
+            new DropdownToolbarAction(
+                'sulu_admin.edit',
+                'su-pen',
+                [
+                    new ToolbarAction('sulu_admin.copy'),
+                ]
+            ),
         ];
         $listToolbarActions = [
             new ToolbarAction('sulu_admin.add'),

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -179,34 +179,11 @@ class FormController extends AbstractRestController implements ClassResourceInte
     {
         $action = $request->query->get('action');
         $locale = $this->getLocale($request);
-        $entity = $this->formManager->findById($id, $locale);
-
-        if (!$entity) {
-            throw new NotFoundHttpException(sprintf('No form with id "%s" was found!', $id));
-        }
 
         try {
             switch ($action) {
                 case 'copy':
-                    $copiedForm = null;
-                    foreach ($entity->getTranslations() as $translation) {
-                        /** @var array{ title: string, fields: mixed[] } $data */
-                        $data = $this->getApiEntity($entity, $translation->getLocale());
-                        $data['title'] = $data['title'] . ' (2)';
-
-                        /** @var array{ options: \stdClass|mixed[] } $field */
-                        foreach ($data['fields'] as &$field) {
-                            if ($field['options'] instanceof \stdClass) {
-                                $field['options'] = [];
-                            }
-                        }
-
-                        $copiedForm = $this->formManager->save(
-                            $data,
-                            $translation->getLocale(),
-                            $copiedForm ? $copiedForm->getId() : null
-                        );
-                    }
+                    $copiedForm = $this->formManager->copy($id);
 
                     return $this->handleView($this->view($this->getApiEntity($copiedForm, $locale)));
                 default:

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -187,7 +187,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
                     try {
                         $copiedForm = $this->formManager->copy($id);
                     } catch (FormNotFoundException $e) {
-                        throw new NotFoundHttpException(sprintf('No form with id "%s" was found!', $e->getFormEntityId()));
+                        throw new NotFoundHttpException(sprintf('No form with id "%s" was found!', $e->getFormEntityId()), $e);
                     }
 
                     return $this->handleView($this->view($this->getApiEntity($copiedForm, $locale)));

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\FormBundle\Controller;
 use FOS\RestBundle\Routing\ClassResourceInterface;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Sulu\Bundle\FormBundle\Entity\Form;
+use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;
 use Sulu\Bundle\FormBundle\Manager\FormManager;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\RestException;
@@ -183,7 +184,11 @@ class FormController extends AbstractRestController implements ClassResourceInte
         try {
             switch ($action) {
                 case 'copy':
-                    $copiedForm = $this->formManager->copy($id);
+                    try {
+                        $copiedForm = $this->formManager->copy($id);
+                    } catch (FormNotFoundException $e) {
+                        throw new NotFoundHttpException(sprintf('No form with id "%s" was found!', $e->getFormEntityId()));
+                    }
 
                     return $this->handleView($this->view($this->getApiEntity($copiedForm, $locale)));
                 default:

--- a/Controller/FormWebsiteController.php
+++ b/Controller/FormWebsiteController.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\FormBundle\Form\HandlerInterface;
 use Sulu\Bundle\FormBundle\Form\Type\AbstractType;
 use Sulu\Bundle\WebsiteBundle\Controller\DefaultController;
 use Sulu\Component\Content\Compat\StructureInterface;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRegistryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -192,6 +193,7 @@ class FormWebsiteController extends DefaultController
         $errors = [];
 
         $generalErrors = [];
+        /** @var FormError $error */
         foreach ($this->form->getErrors() as $error) {
             $generalErrors[] = $error->getMessage();
         }
@@ -203,6 +205,7 @@ class FormWebsiteController extends DefaultController
         foreach ($this->form->all() as $field) {
             $fieldErrors = [];
 
+            /** @var FormError $error */
             foreach ($field->getErrors() as $error) {
                 $fieldErrors[] = $error->getMessage();
             }

--- a/Exception/FormNotFoundException.php
+++ b/Exception/FormNotFoundException.php
@@ -19,7 +19,7 @@ class FormNotFoundException extends \Exception
     private $formEntityId;
 
     /**
-     * @param string $locale
+     * @param string|null $locale
      */
     public function __construct(int $formEntityId, $locale)
     {

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -63,9 +63,13 @@ class DynamicFormType extends AbstractType
     {
         /** @var Form $formEntity */
         $formEntity = $options['formEntity'];
+        /** @var string $locale */
         $locale = $options['locale'];
+        /** @var string $type */
         $type = $options['type'];
+        /** @var string $typeId */
         $typeId = $options['typeId'];
+        /** @var string $name */
         $name = $options['name'];
 
         if (!$translation = $formEntity->getTranslation($locale)) {

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -83,7 +83,9 @@ class FormManager
             $newFormTranslation->setTitle($translation->getTitle() . ' (2)');
             $newFormTranslation->setSubject($translation->getSubject());
             $newFormTranslation->setFromEmail($translation->getFromEmail());
+            $newFormTranslation->setFromName($translation->getFromName());
             $newFormTranslation->setToEmail($translation->getToEmail());
+            $newFormTranslation->setToName($translation->getToName());
             $newFormTranslation->setMailText($translation->getMailText());
             $newFormTranslation->setSubmitLabel($translation->getSubmitLabel());
             $newFormTranslation->setSuccessText($translation->getSuccessText());

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\FormBundle\Manager;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Entity\FormField;
+use Sulu\Bundle\FormBundle\Entity\FormFieldTranslation;
 use Sulu\Bundle\FormBundle\Entity\FormTranslation;
 use Sulu\Bundle\FormBundle\Entity\FormTranslationReceiver;
 use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;
@@ -77,6 +78,7 @@ class FormManager
         $newForm->setDefaultLocale($form->getDefaultLocale());
 
         foreach ($form->getTranslations() as $translation) {
+            /** @var FormTranslation $newFormTranslation */
             $newFormTranslation = $newForm->getTranslation($translation->getLocale(), true);
             $newFormTranslation->setTitle($translation->getTitle() . ' (2)');
             $newFormTranslation->setSubject($translation->getSubject());
@@ -114,6 +116,7 @@ class FormManager
             $newField->setRequired($field->getRequired());
 
             foreach ($field->getTranslations() as $fieldTranslation) {
+                /** @var FormFieldTranslation $newFieldTranslation */
                 $newFieldTranslation = $newField->getTranslation($fieldTranslation->getLocale(), true);
                 $newFieldTranslation->setTitle($fieldTranslation->getTitle());
                 $newFieldTranslation->setPlaceholder($fieldTranslation->getPlaceholder());

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Entity\FormField;
 use Sulu\Bundle\FormBundle\Entity\FormTranslation;
 use Sulu\Bundle\FormBundle\Entity\FormTranslationReceiver;
+use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;
 use Sulu\Bundle\FormBundle\Repository\FormRepository;
 
 class FormManager
@@ -67,6 +68,10 @@ class FormManager
     public function copy(int $id): Form
     {
         $form = $this->findById($id);
+
+        if (!$form) {
+            throw new FormNotFoundException($id, null);
+        }
 
         $newForm = new Form();
         $newForm->setDefaultLocale($form->getDefaultLocale());

--- a/Resources/config/routing_api.yml
+++ b/Resources/config/routing_api.yml
@@ -9,6 +9,13 @@ sulu_form.forms:
     resource: sulu_form.form_controller
     name_prefix: sulu_form.
 
+sulu_form.post_form_trigger:
+    path: /forms/{id}.{_format}
+    methods: POST
+    defaults:
+        _controller: sulu_form.form_controller::postTriggerAction
+        _format: json
+
 sulu_form.dynamic:
     type: rest
     resource: sulu_form.dynamic_controller

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -118,6 +118,47 @@ class FormControllerTest extends SuluTestCase
         $this->assertFullForm($response);
     }
 
+    public function testPostTriggerNotFound(): void
+    {
+        $this->client->request(
+            'POST',
+            '/admin/api/forms/2?action=copy',
+        );
+
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
+    }
+
+    public function testPostTriggerInvalidAction(): void
+    {
+        $form = $this->createMinimalForm();
+
+        $this->client->request(
+            'POST',
+            '/admin/api/forms/' . $form->getId() . '?action=not-an-action',
+        );
+
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
+    }
+
+    public function testPostTriggerCopy(): void
+    {
+        $form = $this->createFullForm();
+
+        $this->client->request(
+            'POST',
+            '/admin/api/forms/' . $form->getId() . '?action=copy',
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('Title (2)', $response['title']);
+        $this->assertNotEquals($form->getId(), $response['id']);
+        $response['title'] = str_replace(' (2)', '', $response['title']);
+
+        $this->assertFullForm($response);
+    }
+
     public function testPutMinimal(): void
     {
         $form = $this->createFullForm();

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -122,7 +122,7 @@ class FormControllerTest extends SuluTestCase
     {
         $this->client->request(
             'POST',
-            '/admin/api/forms/2?action=copy',
+            '/admin/api/forms/2?action=copy'
         );
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());
@@ -134,7 +134,7 @@ class FormControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/admin/api/forms/' . $form->getId() . '?action=not-an-action',
+            '/admin/api/forms/' . $form->getId() . '?action=not-an-action'
         );
 
         $this->assertHttpStatusCode(400, $this->client->getResponse());
@@ -146,7 +146,7 @@ class FormControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/admin/api/forms/' . $form->getId() . '?action=copy',
+            '/admin/api/forms/' . $form->getId() . '?action=copy'
         );
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/doctrine-bundle": "^1.10 || ^2.0",
         "drewm/mailchimp-api": "^2.2",
         "excelwebzone/recaptcha-bundle": "^1.4.2",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3.2",
         "jangregor/phpstan-prophecy": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/orm": "^2.5.3",
         "doctrine/persistence": "^1.3 || ^2.0",
-        "sulu/sulu": "^2.2.0 || 2.3@dev",
+        "sulu/sulu": "^2.4.1 || ^2.4.1@dev",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/console": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1166,6 +1166,11 @@ parameters:
 			path: Form/Builder.php
 
 		-
+			message: "#^Cannot call method getData\\(\\) on mixed\\.$#"
+			count: 4
+			path: Form/Handler.php
+
+		-
 			message: "#^Parameter \\#1 \\$object of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:persist\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: Form/Handler.php
@@ -1631,7 +1636,7 @@ parameters:
 			path: Metadata/DynamicFormMetadataLoader.php
 
 		-
-			message: "#^Cannot call method item\\(\\) on DOMNodeList\\|false\\.$#"
+			message: "#^Cannot call method item\\(\\) on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
 			count: 1
 			path: Metadata/PropertiesXmlLoader.php
 
@@ -1642,6 +1647,11 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: Repository/DynamicRepository.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Repository\\\\DynamicRepository\\:\\:findByFilters\\(\\) should return array but returns mixed\\.$#"
 			count: 1
 			path: Repository/DynamicRepository.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -272,7 +272,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$entity of method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\FormController\\:\\:getApiEntity\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null given\\.$#"
-			count: 1
+			count: 2
 			path: Controller/FormController.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -272,7 +272,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$entity of method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\FormController\\:\\:getApiEntity\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null given\\.$#"
-			count: 2
+			count: 1
 			path: Controller/FormController.php
 
 		-
@@ -1256,42 +1256,7 @@ parameters:
 			path: Form/Type/DynamicFormType.php
 
 		-
-			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:getTranslation\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: Form/Type/DynamicFormType.php
-
-		-
-			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormField\\:\\:getTranslation\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: Form/Type/DynamicFormType.php
-
-		-
-			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Checksum\\:\\:get\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: Form/Type/DynamicFormType.php
-
-		-
-			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\FormBundle\\\\Exception\\\\FormNotFoundException constructor expects string, mixed given\\.$#"
-			count: 1
-			path: Form/Type/DynamicFormType.php
-
-		-
-			message: "#^Parameter \\#2 \\$typeId of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Checksum\\:\\:get\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: Form/Type/DynamicFormType.php
-
-		-
 			message: "#^Parameter \\#3 \\$formId of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Checksum\\:\\:get\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: Form/Type/DynamicFormType.php
-
-		-
-			message: "#^Parameter \\#3 \\$locale of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\FormFieldTypeInterface\\:\\:build\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: Form/Type/DynamicFormType.php
-
-		-
-			message: "#^Parameter \\#4 \\$formName of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Checksum\\:\\:get\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: Form/Type/DynamicFormType.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #151
| Related issues/PRs | depends on https://github.com/sulu/sulu/pull/6475
| License | MIT

#### What's in this PR?

This pull requests adds a toolbar action for creating a copy of the current form to the form edit view. It depends on the toolbar action implemented in https://github.com/sulu/sulu/pull/6475.

#### Why?

See #151
