### PR TITLE
Implement pagination handling for Sendinblue requests

### DIFF
--- a/Dynamic/Helper/SendinblueListSelect.php
+++ b/Dynamic/Helper/SendinblueListSelect.php
@@ -55,7 +55,7 @@ class SendinblueListSelect
         $listObjects = [];
 
         do {
-            $response = $this->contactsApi->getLists((string) $limit, (string) $offset);
+            $response = $this->contactsApi->getLists($limit, $offset);
 
             if (null === $total) {
                 $total = $response->getCount();

--- a/Dynamic/Helper/SendinblueListSelect.php
+++ b/Dynamic/Helper/SendinblueListSelect.php
@@ -22,12 +22,16 @@ use SendinBlue\Client\Configuration;
 class SendinblueListSelect
 {
     /**
-     * @var ContactsApi
+     * @var ContactsApi|null
      */
     private $contactsApi;
 
     public function __construct(?string $apiKey)
     {
+        if (!$apiKey) {
+            return;
+        }
+
         $config = new Configuration();
         $config->setApiKey('api-key', $apiKey);
 
@@ -41,9 +45,33 @@ class SendinblueListSelect
      */
     public function getValues(): array
     {
+        if (!$this->contactsApi) {
+            return [];
+        }
+
+        $limit = 50;
+        $offset = 0;
+        $total = null;
+        $listObjects = [];
+
+        do {
+            $response = $this->contactsApi->getLists((string) $limit, (string) $offset);
+
+            if (null === $total) {
+                $total = $response->getCount();
+            }
+
+            $newListObjects = $response->getLists();
+            if (0 === \count($newListObjects)) {
+                break;
+            }
+
+            $listObjects = array_merge($listObjects, $newListObjects);
+            $offset += $limit;
+        } while (count($listObjects) < $total);
+
         $lists = [];
 
-        $listObjects = $this->contactsApi->getLists()->getLists();
         foreach ($listObjects as $list) {
             $lists[] = [
                 'name' => $list['id'],

--- a/Dynamic/Helper/SendinblueMailTemplateSelect.php
+++ b/Dynamic/Helper/SendinblueMailTemplateSelect.php
@@ -55,7 +55,7 @@ class SendinblueMailTemplateSelect
         $mailTemplateObjects = [];
 
         do {
-            $response = $this->transactionalEmailsApi->getSmtpTemplates('true', (string) $limit, (string) $offset);
+            $response = $this->transactionalEmailsApi->getSmtpTemplates('true', $limit, $offset);
 
             if (null === $total) {
                 $total = $response->getCount();

--- a/Dynamic/Helper/SendinblueMailTemplateSelect.php
+++ b/Dynamic/Helper/SendinblueMailTemplateSelect.php
@@ -22,12 +22,16 @@ use SendinBlue\Client\Configuration;
 class SendinblueMailTemplateSelect
 {
     /**
-     * @var TransactionalEmailsApi
+     * @var TransactionalEmailsApi|null
      */
     private $transactionalEmailsApi;
 
     public function __construct(?string $apiKey)
     {
+        if (!$apiKey) {
+            return;
+        }
+
         $config = new Configuration();
         $config->setApiKey('api-key', $apiKey);
 
@@ -41,9 +45,33 @@ class SendinblueMailTemplateSelect
      */
     public function getValues(): array
     {
+        if (!$this->transactionalEmailsApi) {
+            return [];
+        }
+
+        $limit = 50;
+        $offset = 0;
+        $total = null;
+        $mailTemplateObjects = [];
+
+        do {
+            $response = $this->transactionalEmailsApi->getSmtpTemplates('true', (string) $limit, (string) $offset);
+
+            if (null === $total) {
+                $total = $response->getCount();
+            }
+
+            $newMailTemplateObjects = $response->getTemplates();
+            if (0 === \count($newMailTemplateObjects)) {
+                break;
+            }
+
+            $mailTemplateObjects = array_merge($mailTemplateObjects, $newMailTemplateObjects);
+            $offset += $limit;
+        } while (count($mailTemplateObjects) < $total);
+
         $mailTemplates = [];
 
-        $mailTemplateObjects = $this->transactionalEmailsApi->getSmtpTemplates('true')->getTemplates();
         foreach ($mailTemplateObjects as $template) {
             if (($template['tag'] ?? null) !== 'optin') {
                 continue;

--- a/Event/SendinblueListSubscriber.php
+++ b/Event/SendinblueListSubscriber.php
@@ -31,13 +31,17 @@ class SendinblueListSubscriber implements EventSubscriberInterface
     private $requestStack;
 
     /**
-     * @var ContactsApi
+     * @var ContactsApi|null
      */
     private $contactsApi;
 
     public function __construct(RequestStack $requestStack, ?string $apiKey)
     {
         $this->requestStack = $requestStack;
+
+        if (!$apiKey) {
+            return;
+        }
 
         $config = new Configuration();
         $config->setApiKey('api-key', $apiKey);
@@ -57,6 +61,10 @@ class SendinblueListSubscriber implements EventSubscriberInterface
 
     public function listSubscribe(FormSavePostEvent $event): void
     {
+        if (!$this->contactsApi) {
+            return;
+        }
+
         $dynamic = $event->getData();
         $request = $this->requestStack->getCurrentRequest();
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -401,11 +401,6 @@ parameters:
 			path: Dynamic/Helper/SendinblueListSelect.php
 
 		-
-			message: "#^Parameter \\#2 \\$key of method SendinBlue\\\\Client\\\\Configuration\\:\\:setApiKey\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: Dynamic/Helper/SendinblueListSelect.php
-
-		-
 			message: "#^Cannot assign offset 'tag' to SendinBlue\\\\Client\\\\Model\\\\GetSmtpTemplateOverview\\.$#"
 			count: 1
 			path: Dynamic/Helper/SendinblueMailTemplateSelect.php
@@ -417,11 +412,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$templateStatus of method SendinBlue\\\\Client\\\\Api\\\\TransactionalEmailsApi\\:\\:getSmtpTemplates\\(\\) expects bool\\|null, string given\\.$#"
-			count: 1
-			path: Dynamic/Helper/SendinblueMailTemplateSelect.php
-
-		-
-			message: "#^Parameter \\#2 \\$key of method SendinBlue\\\\Client\\\\Configuration\\:\\:setApiKey\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: Dynamic/Helper/SendinblueMailTemplateSelect.php
 
@@ -1058,11 +1048,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'value' on mixed\\.$#"
 			count: 4
-			path: Event/SendinblueListSubscriber.php
-
-		-
-			message: "#^Parameter \\#2 \\$key of method SendinBlue\\\\Client\\\\Configuration\\:\\:setApiKey\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
 			path: Event/SendinblueListSubscriber.php
 
 		-


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Implement pagination handling for Sendinblue requests

#### Why?

Until now, only the first 10 sendinblue lists and mail templates have been requested at the sendinblue api
