### PR TITLE
Implement domain events and integrate activity bundle

### DIFF
--- a/Admin/FormAdmin.php
+++ b/Admin/FormAdmin.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -25,6 +26,7 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 
 class FormAdmin extends Admin
 {
+    public const SECURITY_CONTEXT = 'sulu.form.forms';
     public const LIST_VIEW = 'sulu_form.list';
     public const LIST_VIEW_DATA = 'sulu_form.edit_form.data';
     public const ADD_FORM_VIEW = 'sulu_form.add_form';
@@ -62,7 +64,7 @@ class FormAdmin extends Admin
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
     {
-        if ($this->securityChecker->hasPermission('sulu.form.forms', PermissionTypes::VIEW)) {
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
             $navigationItem = new NavigationItem('sulu_form.forms');
             $navigationItem->setIcon('su-magic');
             $navigationItem->setPosition(10);
@@ -104,7 +106,7 @@ class FormAdmin extends Admin
 
         $viewCollection->add(
             $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/forms/:locale')
-                ->setResourceKey('forms')
+                ->setResourceKey(Form::RESOURCE_KEY)
                 ->setListKey('forms')
                 ->setTitle('sulu_form.forms')
                 ->addListAdapters(['table'])
@@ -117,13 +119,13 @@ class FormAdmin extends Admin
         );
         $viewCollection->add(
             $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_FORM_VIEW, '/forms/:locale/add')
-                ->setResourceKey('forms')
+                ->setResourceKey(Form::RESOURCE_KEY)
                 ->addLocales($formLocales)
                 ->setBackView(static::LIST_VIEW)
         );
         $viewCollection->add(
             $this->viewBuilderFactory->createFormViewBuilder(static::ADD_FORM_DETAILS_VIEW, '/details')
-                ->setResourceKey('forms')
+                ->setResourceKey(Form::RESOURCE_KEY)
                 ->setFormKey('form_details')
                 ->setTabTitle('sulu_form.general')
                 ->setEditView(static::EDIT_FORM_VIEW)
@@ -132,13 +134,13 @@ class FormAdmin extends Admin
         );
         $viewCollection->add(
             $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_FORM_VIEW, '/forms/:locale/:id')
-                ->setResourceKey('forms')
+                ->setResourceKey(Form::RESOURCE_KEY)
                 ->addLocales($formLocales)
                 ->setBackView(static::LIST_VIEW)
         );
         $viewCollection->add(
             $this->viewBuilderFactory->createFormViewBuilder(static::EDIT_FORM_DETAILS_VIEW, '/details')
-                ->setResourceKey('forms')
+                ->setResourceKey(Form::RESOURCE_KEY)
                 ->setFormKey('form_details')
                 ->setTabTitle('sulu_form.general')
                 ->addToolbarActions($formToolbarActions)
@@ -162,7 +164,7 @@ class FormAdmin extends Admin
         return [
             'Sulu' => [
                 'Form' => [
-                    'sulu.form.forms' => [
+                    static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,
                         PermissionTypes::ADD,
                         PermissionTypes::EDIT,

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\FormBundle\Controller;
 
 use FOS\RestBundle\Routing\ClassResourceInterface;
 use FOS\RestBundle\View\ViewHandlerInterface;
+use Sulu\Bundle\FormBundle\Admin\FormAdmin;
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;
 use Sulu\Bundle\FormBundle\Manager\FormManager;
@@ -79,7 +80,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
      */
     public function getSecurityContext()
     {
-        return 'sulu.form.forms';
+        return FormAdmin::SECURITY_CONTEXT;
     }
 
     public function getModelClass(): string
@@ -104,7 +105,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
             $listBuilder = $this->factory->create($this->getModelClass());
 
             // get fieldDescriptors
-            $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('forms');
+            $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors(Form::RESOURCE_KEY);
 
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
@@ -183,7 +184,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
             switch ($action) {
                 case 'copy':
                     try {
-                        $copiedForm = $this->formManager->copy($id);
+                        $copiedForm = $this->formManager->copy($id, $locale);
                     } catch (FormNotFoundException $e) {
                         throw new NotFoundHttpException(\sprintf('No form with id "%s" was found!', $e->getFormEntityId()), $e);
                     }

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\FormBundle\DependencyInjection;
 
 use Sulu\Bundle\FormBundle\Controller\FormTokenController;
 use Sulu\Bundle\FormBundle\Controller\FormWebsiteController;
+use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -89,7 +90,7 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
                         ],
                     ],
                     'resources' => [
-                        'forms' => [
+                        Form::RESOURCE_KEY => [
                             'routes' => [
                                 'list' => 'sulu_form.get_forms',
                                 'detail' => 'sulu_form.get_form',
@@ -106,7 +107,7 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
                         'single_selection' => [
                             'single_form_selection' => [
                                 'default_type' => 'list_overlay',
-                                'resource_key' => 'forms',
+                                'resource_key' => Form::RESOURCE_KEY,
                                 'types' => [
                                     'list_overlay' => [
                                         'adapter' => 'table',

--- a/Domain/Event/FormCopiedEvent.php
+++ b/Domain/Event/FormCopiedEvent.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\FormBundle\Admin\FormAdmin;
+use Sulu\Bundle\FormBundle\Entity\Form;
+use Sulu\Bundle\FormBundle\Entity\FormTranslation;
+
+class FormCopiedEvent extends DomainEvent
+{
+    /**
+     * @var Form
+     */
+    private $form;
+
+    /**
+     * @var int
+     */
+    private $sourceFormId;
+
+    /**
+     * @var string
+     */
+    private $sourceFormTitle;
+
+    /**
+     * @var string
+     */
+    private $sourceFormTitleLocale;
+
+    public function __construct(
+        Form $form,
+        int $sourceFormId,
+        string $sourceFormTitle,
+        string $sourceFormTitleLocale
+    ) {
+        parent::__construct();
+
+        $this->form = $form;
+        $this->sourceFormId = $sourceFormId;
+        $this->sourceFormTitle = $sourceFormTitle;
+        $this->sourceFormTitleLocale = $sourceFormTitleLocale;
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
+    }
+
+    public function getEventType(): string
+    {
+        return 'copied';
+    }
+
+    public function getEventContext(): array
+    {
+        return [
+            'sourceFormId' => $this->sourceFormId,
+            'sourceFormTitle' => $this->sourceFormTitle,
+            'sourceFormTitleLocale' => $this->sourceFormTitleLocale,
+        ];
+    }
+
+    public function getResourceKey(): string
+    {
+        return Form::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->form->getId();
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getTitle() : null;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getLocale() : null;
+    }
+
+    private function getFormTranslation(): ?FormTranslation
+    {
+        return $this->form->getTranslation($this->form->getDefaultLocale());
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return FormAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/Domain/Event/FormCreatedEvent.php
+++ b/Domain/Event/FormCreatedEvent.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\FormBundle\Admin\FormAdmin;
+use Sulu\Bundle\FormBundle\Entity\Form;
+use Sulu\Bundle\FormBundle\Entity\FormTranslation;
+
+class FormCreatedEvent extends DomainEvent
+{
+    /**
+     * @var Form
+     */
+    private $form;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var mixed[]
+     */
+    private $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(
+        Form $form,
+        string $locale,
+        array $payload
+    ) {
+        parent::__construct();
+
+        $this->form = $form;
+        $this->locale = $locale;
+        $this->payload = $payload;
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
+    }
+
+    public function getEventType(): string
+    {
+        return 'created';
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getResourceKey(): string
+    {
+        return Form::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->form->getId();
+    }
+
+    public function getResourceLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getTitle() : null;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getLocale() : null;
+    }
+
+    private function getFormTranslation(): ?FormTranslation
+    {
+        return $this->form->getTranslation($this->locale, false, true);
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return FormAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/Domain/Event/FormModifiedEvent.php
+++ b/Domain/Event/FormModifiedEvent.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\FormBundle\Admin\FormAdmin;
+use Sulu\Bundle\FormBundle\Entity\Form;
+use Sulu\Bundle\FormBundle\Entity\FormTranslation;
+
+class FormModifiedEvent extends DomainEvent
+{
+    /**
+     * @var Form
+     */
+    private $form;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var mixed[]
+     */
+    private $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(
+        Form $form,
+        string $locale,
+        array $payload
+    ) {
+        parent::__construct();
+
+        $this->form = $form;
+        $this->locale = $locale;
+        $this->payload = $payload;
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
+    }
+
+    public function getEventType(): string
+    {
+        return 'modified';
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getResourceKey(): string
+    {
+        return Form::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->form->getId();
+    }
+
+    public function getResourceLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getTitle() : null;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getLocale() : null;
+    }
+
+    private function getFormTranslation(): ?FormTranslation
+    {
+        return $this->form->getTranslation($this->locale, false, true);
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return FormAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/Domain/Event/FormRemovedEvent.php
+++ b/Domain/Event/FormRemovedEvent.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\FormBundle\Admin\FormAdmin;
+use Sulu\Bundle\FormBundle\Entity\Form;
+
+class FormRemovedEvent extends DomainEvent
+{
+    /**
+     * @var int
+     */
+    private $formId;
+
+    /**
+     * @var string|null
+     */
+    private $formTitle;
+
+    /**
+     * @var string|null
+     */
+    private $formTitleLocale;
+
+    public function __construct(
+        int $formId,
+        ?string $categoryTitle,
+        ?string $categoryTitleLocale
+    ) {
+        parent::__construct();
+
+        $this->formId = $formId;
+        $this->formTitle = $categoryTitle;
+        $this->formTitleLocale = $categoryTitleLocale;
+    }
+
+    public function getEventType(): string
+    {
+        return 'removed';
+    }
+
+    public function getResourceKey(): string
+    {
+        return Form::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->formId;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->formTitle;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->formTitleLocale;
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return FormAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/Domain/Event/FormTranslationAddedEvent.php
+++ b/Domain/Event/FormTranslationAddedEvent.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\FormBundle\Admin\FormAdmin;
+use Sulu\Bundle\FormBundle\Entity\Form;
+use Sulu\Bundle\FormBundle\Entity\FormTranslation;
+
+class FormTranslationAddedEvent extends DomainEvent
+{
+    /**
+     * @var Form
+     */
+    private $form;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var mixed[]
+     */
+    private $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(
+        Form $form,
+        string $locale,
+        array $payload
+    ) {
+        parent::__construct();
+
+        $this->form = $form;
+        $this->locale = $locale;
+        $this->payload = $payload;
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
+    }
+
+    public function getEventType(): string
+    {
+        return 'translation_added';
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getResourceKey(): string
+    {
+        return Form::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->form->getId();
+    }
+
+    public function getResourceLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getTitle() : null;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        $translation = $this->getFormTranslation();
+
+        return $translation ? $translation->getLocale() : null;
+    }
+
+    private function getFormTranslation(): ?FormTranslation
+    {
+        return $this->form->getTranslation($this->locale, false, true);
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return FormAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/Entity/Form.php
+++ b/Entity/Form.php
@@ -19,6 +19,8 @@ use Doctrine\Common\Collections\Collection;
  */
 class Form
 {
+    public const RESOURCE_KEY = 'forms';
+
     /**
      * @var null|int
      */

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -51,7 +51,7 @@
                  class="Sulu\Bundle\FormBundle\Manager\FormManager" public="true">
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="sulu_form.repository.form" />
-            <argument type="service" id="`" on-invalid="null" />
+            <argument type="service" id="sulu_activity.domain_event_collector"/>
         </service>
 
         <!-- Content Types -->
@@ -207,6 +207,7 @@
             <argument type="service" id="sulu_core.doctrine_list_builder_factory"/>
             <argument type="service" id="sulu_core.list_builder.field_descriptor_factory"/>
             <argument type="service" id="sulu_core.list_rest_helper"/>
+            <argument type="service" id="sulu_activity.domain_event_dispatcher"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/Resources/translations/admin.de.json
+++ b/Resources/translations/admin.de.json
@@ -85,5 +85,10 @@
   "sulu_form.salutation_mr": "Herr",
   "sulu_form.salutation_ms": "Frau",
   "sulu_form.single_form_selection.no_form_selected": "Kein Formular ausgewählt",
-  "sulu_form.single_form_selection.overlay_title": "Wählen Sie ein Formular aus"
+  "sulu_form.single_form_selection.overlay_title": "Wählen Sie ein Formular aus",
+  "sulu_activity.description.forms.created": "{userFullName} hat das Formular \"{resourceTitle}\" erstellt",
+  "sulu_activity.description.forms.modified": "{userFullName} hat das Formular \"{resourceTitle}\" geändert",
+  "sulu_activity.description.forms.translation_added": "{userFullName} hat eine Übersetzung für \"{resourceLocale}\" zum Forumlar \"{resourceTitle}\" hinzugefügt",
+  "sulu_activity.description.forms.removed": "{userFullName} hat das Formular \"{resourceTitle}\" gelöscht",
+  "sulu_activity.description.forms.copied": "{userFullName} hat das Formular \"{resourceTitle}\" kopiert"
 }

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -85,5 +85,10 @@
   "sulu_form.salutation_mr": "Mr.",
   "sulu_form.salutation_ms": "Ms.",
   "sulu_form.single_form_selection.no_form_selected": "No form selected",
-  "sulu_form.single_form_selection.overlay_title": "Select a form"
+  "sulu_form.single_form_selection.overlay_title": "Select a form",
+  "sulu_activity.description.forms.created": "{userFullName} has created the form \"{resourceTitle}\"",
+  "sulu_activity.description.forms.modified": "{userFullName} has changed the form \"{resourceTitle}\"",
+  "sulu_activity.description.forms.translation_added": "{userFullName} has added a translation \"{resourceLocale}\" to the form \"{resourceTitle}\"",
+  "sulu_activity.description.forms.removed": "{userFullName} has removed the form \"{resourceTitle}\"",
+  "sulu_activity.description.forms.copied": "{userFullName} has copied the form \"{resourceTitle}\""
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -276,11 +276,6 @@ parameters:
 			path: Controller/FormController.php
 
 		-
-			message: "#^Parameter \\#1 \\$form of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormCopiedEvent constructor expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null given\\.$#"
-			count: 1
-			path: Controller/FormController.php
-
-		-
 			message: "#^Parameter \\#2 \\$fieldDescriptors of method Sulu\\\\Component\\\\Rest\\\\RestHelperInterface\\:\\:initializeListBuilder\\(\\) expects array\\<Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\>, array\\<Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\>\\|null given\\.$#"
 			count: 1
 			path: Controller/FormController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -276,6 +276,11 @@ parameters:
 			path: Controller/FormController.php
 
 		-
+			message: "#^Parameter \\#1 \\$form of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormCopiedEvent constructor expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null given\\.$#"
+			count: 1
+			path: Controller/FormController.php
+
+		-
 			message: "#^Parameter \\#2 \\$fieldDescriptors of method Sulu\\\\Component\\\\Rest\\\\RestHelperInterface\\:\\:initializeListBuilder\\(\\) expects array\\<Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\>, array\\<Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\>\\|null given\\.$#"
 			count: 1
 			path: Controller/FormController.php
@@ -1532,7 +1537,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:getTranslation\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
+			count: 3
 			path: Manager/FormManager.php
 
 		-
@@ -1577,6 +1582,21 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormCreatedEvent constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormModifiedEvent constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormTranslationAddedEvent constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: Manager/FormManager.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | builds upon #316
| License | MIT

#### What's in this PR?

This pull requests integrates the form bundle into the activity log feature of the `SuluActivityBundle`.

#### Why?

Because it might be helpful to check when a form was created/modified/removed in some cases. Also, we want to integrate the activity log feature into all ou bundles eventually. 
