### PR TITLE
Add possibility to add additional spam checkers

### DIFF
--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\FormBundle\DependencyInjection;
 
 use Sulu\Bundle\FormBundle\Controller\FormTokenController;
 use Sulu\Bundle\FormBundle\Controller\FormWebsiteController;
+use Sulu\Bundle\FormBundle\SpamChecker\SpamCheckerInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -229,6 +230,7 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         }
 
         $this->configureHelper($loader, $config, $container);
+        $this->registerInterfacesForAutoconfiguration($container);
     }
 
     /**
@@ -256,5 +258,11 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         }
 
         $container->setAlias('sulu.mail.helper', 'sulu.mail.' . $helper);
+    }
+
+    private function registerInterfacesForAutoconfiguration(ContainerBuilder $container): void
+    {
+        $container->registerForAutoconfiguration(SpamCheckerInterface::class)
+            ->addTag('sulu_form.spam_checker');
     }
 }

--- a/Exception/FormSubmissionIsSpamException.php
+++ b/Exception/FormSubmissionIsSpamException.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Exception;
+
+class FormSubmissionIsSpamException extends \Exception implements FormSubmissionIsSpamExceptionInterface
+{
+    /**
+     * @var string
+     */
+    private $spamStrategy;
+
+    /**
+     * @var string
+     */
+    private $reason;
+
+    /**
+     * @see SpamCheckerInterface::SPAM_STRATEGY_SPAM
+     * @see SpamCheckerInterface::SPAM_STRATEGY_NO_SAVE
+     * @see SpamCheckerInterface::SPAM_STRATEGY_NO_EMAIL
+     */
+    public function __construct(string $spamStrategy, string $reason)
+    {
+        $this->spamStrategy = $spamStrategy;
+        $this->reason = $reason;
+
+        parent::__construct(
+            sprintf('FormSubmission has been marked as spam because of "%s" with strategy "%s"', $reason, $spamStrategy)
+        );
+    }
+
+    public function getSpamStrategy(): string
+    {
+        return $this->spamStrategy;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+}

--- a/Exception/FormSubmissionIsSpamExceptionInterface.php
+++ b/Exception/FormSubmissionIsSpamExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Exception;
+
+interface FormSubmissionIsSpamExceptionInterface extends \Throwable
+{
+    public function getSpamStrategy(): string;
+
+    public function getReason(): string;
+}

--- a/Form/HandlerInterface.php
+++ b/Form/HandlerInterface.php
@@ -14,19 +14,40 @@ namespace Sulu\Bundle\FormBundle\Form;
 use Sulu\Bundle\FormBundle\Configuration\FormConfigurationInterface;
 use Sulu\Bundle\FormBundle\Event\FormSavePostEvent;
 use Sulu\Bundle\FormBundle\Event\FormSavePreEvent;
+use Sulu\Bundle\FormBundle\SpamChecker\SpamCheckerInterface;
 use Symfony\Component\Form\FormInterface;
 
 interface HandlerInterface
 {
-    /** @deprecated use FormSavePreEvent::NAME instead */
+    /**
+     * @deprecated
+     * @see FormSavePreEvent::NAME
+     */
     const EVENT_FORM_SAVE = FormSavePreEvent::NAME;
 
-    /** @deprecated use FormSavePostEvent::NAME instead */
+    /**
+     * @deprecated
+     * @see FormSavePostEvent::NAME
+     */
     const EVENT_FORM_SAVED = FormSavePostEvent::NAME;
 
-    const HONEY_POT_STRATEGY_NO_SAVE = 'no_save';
-    const HONEY_POT_STRATEGY_NO_EMAIL = 'no_email';
-    const HONEY_POT_STRATEGY_SPAM = 'spam';
+    /**
+     * @deprecated
+     * @see SpamCheckerInterface::SPAM_STRATEGY_NO_SAVE
+     */
+    const HONEY_POT_STRATEGY_NO_SAVE = SpamCheckerInterface::SPAM_STRATEGY_NO_SAVE;
+
+    /**
+     * @deprecated
+     * @see SpamCheckerInterface::SPAM_STRATEGY_NO_EMAIL
+     */
+    const HONEY_POT_STRATEGY_NO_EMAIL = SpamCheckerInterface::SPAM_STRATEGY_NO_EMAIL;
+
+    /**
+     * @deprecated
+     * @see SpamCheckerInterface::SPAM_STRATEGY_SPAM
+     */
+    const HONEY_POT_STRATEGY_SPAM = SpamCheckerInterface::SPAM_STRATEGY_SPAM;
 
     public function handle(FormInterface $form, FormConfigurationInterface $configuration): bool;
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,6 +15,7 @@
             <argument type="service" id="sulu_media.media_manager" />
             <argument>%sulu_form.honeypot_strategy%</argument>
             <argument>%sulu_form.honeypot_field%</argument>
+            <argument type="service" id="sulu_form.spam_checker"/>
         </service>
         <service id="Sulu\Bundle\FormBundle\Form\HandlerInterface" alias="sulu_form.handler"/>
 
@@ -266,6 +267,18 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
 
             <tag name="console.command"/>
+        </service>
+
+        <!-- SpamCheckers -->
+        <service id="sulu_form.spam_checker" class="Sulu\Bundle\FormBundle\SpamChecker\SpamChecker">
+            <argument type="tagged" tag="sulu_form.spam_checker"/>
+        </service>
+        <service id="Sulu\Bundle\FormBundle\SpamChecker\SpamCheckerInterface" alias="sulu_form.spam_checker"/>
+
+        <service id="sulu_form.honeypot_spam_checker" class="Sulu\Bundle\FormBundle\SpamChecker\HoneypotSpamChecker">
+            <argument>%sulu_form.honeypot_field%</argument>
+            <argument>%sulu_form.honeypot_strategy%</argument>
+            <tag name="sulu_form.spam_checker"/>
         </service>
     </services>
 </container>

--- a/SpamChecker/HoneypotSpamChecker.php
+++ b/SpamChecker/HoneypotSpamChecker.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\SpamChecker;
+
+use Sulu\Bundle\FormBundle\Configuration\FormConfigurationInterface;
+use Sulu\Bundle\FormBundle\Exception\FormSubmissionIsSpamException;
+use Symfony\Component\Form\FormInterface;
+
+class HoneypotSpamChecker implements SpamCheckerInterface
+{
+    public const SPAM_REASON_HONEYPOT = 'honeypot';
+
+    /**
+     * @var string|null
+     */
+    private $honeyPotField;
+
+    /**
+     * @var string
+     */
+    private $honeyPotSpamStrategy;
+
+    public function __construct(?string $honeyPotField, ?string $honeyPotSpamStrategy)
+    {
+        $this->honeyPotField = $honeyPotField;
+        $this->honeyPotSpamStrategy = $honeyPotSpamStrategy ?? self::SPAM_STRATEGY_SPAM;
+    }
+
+    public function check(FormInterface $form, FormConfigurationInterface $formConfiguration): void
+    {
+        if (!$this->honeyPotField) {
+            return;
+        }
+
+        $honeypotFieldName = str_replace(' ', '_', strtolower($this->honeyPotField));
+
+        if (!$form->has($honeypotFieldName)) {
+            return;
+        }
+
+        $honeypotField = $form->get($honeypotFieldName);
+
+        if (!$honeypotField->getData()) {
+            return;
+        }
+
+        throw new FormSubmissionIsSpamException($this->honeyPotSpamStrategy, self::SPAM_REASON_HONEYPOT);
+    }
+}

--- a/SpamChecker/SpamChecker.php
+++ b/SpamChecker/SpamChecker.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\SpamChecker;
+
+use Sulu\Bundle\FormBundle\Configuration\FormConfigurationInterface;
+use Sulu\Bundle\FormBundle\Exception\FormSubmissionIsSpamExceptionInterface;
+use Symfony\Component\Form\FormInterface;
+
+class SpamChecker implements SpamCheckerInterface
+{
+    protected const PRIORITIZED_SPAM_STRATEGIES = [
+        self::SPAM_STRATEGY_NO_SAVE => 30,
+        self::SPAM_STRATEGY_NO_EMAIL => 20,
+        self::SPAM_STRATEGY_SPAM => 10,
+    ];
+
+    /**
+     * @var iterable<SpamCheckerInterface>
+     */
+    private $spamCheckers;
+
+    /**
+     * @param iterable<SpamCheckerInterface> $spamCheckers
+     */
+    public function __construct(iterable $spamCheckers)
+    {
+        $this->spamCheckers = $spamCheckers;
+    }
+
+    public function check(FormInterface $form, FormConfigurationInterface $formConfiguration): void
+    {
+        $highestPriority = 0;
+        $exception = null;
+
+        foreach ($this->spamCheckers as $spamChecker) {
+            try {
+                $spamChecker->check($form, $formConfiguration);
+            } catch (FormSubmissionIsSpamExceptionInterface $e) {
+                $priority = self::getPriorityForException($e);
+
+                if (null === $exception || $priority > $highestPriority) {
+                    $exception = $e;
+                    $highestPriority = $priority;
+                }
+            }
+        }
+
+        if (null !== $exception) {
+            throw $exception;
+        }
+    }
+
+    protected static function getPriorityForException(FormSubmissionIsSpamExceptionInterface $e): int
+    {
+        $spamStrategy = $e->getSpamStrategy();
+
+        return static::PRIORITIZED_SPAM_STRATEGIES[$spamStrategy] ?? 0;
+    }
+}

--- a/SpamChecker/SpamCheckerInterface.php
+++ b/SpamChecker/SpamCheckerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\SpamChecker;
+
+use Sulu\Bundle\FormBundle\Configuration\FormConfigurationInterface;
+use Sulu\Bundle\FormBundle\Exception\FormSubmissionIsSpamExceptionInterface;
+use Symfony\Component\Form\FormInterface;
+
+interface SpamCheckerInterface
+{
+    const SPAM_STRATEGY_NO_SAVE = 'no_save';
+    const SPAM_STRATEGY_NO_EMAIL = 'no_email';
+    const SPAM_STRATEGY_SPAM = 'spam';
+
+    /**
+     * @throws FormSubmissionIsSpamExceptionInterface
+     */
+    public function check(FormInterface $form, FormConfigurationInterface $formConfiguration): void;
+}

--- a/Tests/Unit/SpamChecker/SpamCheckerTest.php
+++ b/Tests/Unit/SpamChecker/SpamCheckerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Tests\SpamChecker;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\FormBundle\Configuration\FormConfigurationInterface;
+use Sulu\Bundle\FormBundle\Exception\FormSubmissionIsSpamException;
+use Sulu\Bundle\FormBundle\SpamChecker\SpamChecker;
+use Sulu\Bundle\FormBundle\SpamChecker\SpamCheckerInterface;
+use Symfony\Component\Form\FormInterface;
+
+class SpamCheckerTest extends TestCase
+{
+    /**
+     * @var SpamChecker
+     */
+    private $spamChecker;
+
+    public function setUp(): void
+    {
+        $spamChecker1 = $this->prophesize(SpamCheckerInterface::class);
+        $spamChecker1->check(Argument::any(), Argument::any())->willThrow(
+            new FormSubmissionIsSpamException(SpamCheckerInterface::SPAM_STRATEGY_SPAM, 'spamChecker1')
+        );
+
+        $spamChecker2 = $this->prophesize(SpamCheckerInterface::class);
+        $spamChecker2->check(Argument::any(), Argument::any())->willThrow(
+            new FormSubmissionIsSpamException(SpamCheckerInterface::SPAM_STRATEGY_NO_SAVE, 'spamChecker2')
+        );
+
+        $spamChecker3 = $this->prophesize(SpamCheckerInterface::class);
+        $spamChecker3->check(Argument::any(), Argument::any())->willThrow(
+            new FormSubmissionIsSpamException(SpamCheckerInterface::SPAM_STRATEGY_NO_EMAIL, 'spamChecker3')
+        );
+
+        $spamChecker4 = $this->prophesize(SpamCheckerInterface::class);
+        $spamChecker4->check(Argument::any(), Argument::any())->willThrow(
+            new FormSubmissionIsSpamException(SpamCheckerInterface::SPAM_STRATEGY_NO_SAVE, 'spamChecker4')
+        );
+
+        $this->spamChecker = new SpamChecker([
+            $spamChecker1->reveal(),
+            $spamChecker2->reveal(),
+            $spamChecker3->reveal(),
+            $spamChecker4->reveal(),
+        ]);
+    }
+
+    public function testCheck(): void
+    {
+        $this->expectExceptionObject(
+            new FormSubmissionIsSpamException(SpamCheckerInterface::SPAM_STRATEGY_NO_SAVE, 'spamChecker2')
+        );
+
+        $form = $this->prophesize(FormInterface::class);
+        $formConfiguration = $this->prophesize(FormConfigurationInterface::class);
+
+        $this->spamChecker->check($form->reveal(), $formConfiguration->reveal());
+    }
+}

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## 2.x
+
+### Handler constructor changed
+
+The `Handler` service now accepts a new argument `$spamChecker`. If you have overridden this service in your project,
+you should inject the `sulu_form.spam_checker` service manually.
+
 ## 2.1.1
 
 ### Builder constructor changed


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Add possibility to add additional spam checkers.

#### Example Usage

The `HoneypotSpamChecker` can be used as example
