### PR TITLE
Replacing return's magic number with Symfony Command constant

### DIFF
--- a/Command/FormGeneratorCommand.php
+++ b/Command/FormGeneratorCommand.php
@@ -214,7 +214,7 @@ class FormGeneratorCommand extends Command
 
         $output->writeln('A form called "Test Form" has been successfully created/updated.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Replacing return's magic number `0` with Symfony [`Command::SUCCESS`](https://github.com/symfony/symfony/blob/cd25802d37586a8e2372d2a2abbe5a9274b414f9/src/Symfony/Component/Console/Command/Command.php#L38) constant

#### Why?

Helps improve code readability and maintainability
