### PR TITLE
Add help text to the DynamicFormType

### DIFF
--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -381,6 +381,7 @@ class FormController extends AbstractRestController implements ClassResourceInte
             if ($fieldTranslation) {
                 $fieldData['title'] = $fieldTranslation->getTitle();
                 $fieldData['placeholder'] = $fieldTranslation->getPlaceholder();
+                $fieldData['help'] = $fieldTranslation->getHelp();
                 $fieldData['defaultValue'] = $fieldTranslation->getDefaultValue();
                 $fieldData['shortTitle'] = $fieldTranslation->getShortTitle();
                 $fieldData['options'] = $fieldTranslation->getOptions();

--- a/Entity/Form.php
+++ b/Entity/Form.php
@@ -216,6 +216,7 @@ class Form
                 'options' => $fieldTranslation->getOptions(),
                 'defaultValue' => $fieldTranslation->getDefaultValue(),
                 'placeholder' => $fieldTranslation->getPlaceholder(),
+                'help' => $fieldTranslation->getHelp(),
                 'shortTitle' => $fieldTranslation->getShortTitle(),
                 'value' => $value,
             ];

--- a/Entity/FormFieldTranslation.php
+++ b/Entity/FormFieldTranslation.php
@@ -49,6 +49,11 @@ class FormFieldTranslation
     /**
      * @var null|string
      */
+    private $help;
+
+    /**
+     * @var null|string
+     */
     private $shortTitle;
 
     /**
@@ -115,6 +120,18 @@ class FormFieldTranslation
     public function setPlaceholder(?string $placeholder): self
     {
         $this->placeholder = $placeholder;
+
+        return $this;
+    }
+
+    public function getHelp(): ?string
+    {
+        return $this->help;
+    }
+
+    public function setHelp(?string $help): self
+    {
+        $this->help = $help;
 
         return $this;
     }

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -93,6 +93,7 @@ class DynamicFormType extends AbstractType
 
             $title = $fieldTranslation->getTitle();
             $placeholder = $fieldTranslation->getPlaceholder();
+            $help = $fieldTranslation->getHelp();
             $width = $field->getWidth() ?: 'full';
 
             $nextField = null;
@@ -111,6 +112,11 @@ class DynamicFormType extends AbstractType
 
             if ($placeholder) {
                 $options['attr']['placeholder'] = $placeholder;
+            }
+
+            if ($help) {
+                $options['help_html'] = true;
+                $options['help'] = $help;
             }
 
             // required

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -143,6 +143,7 @@ class FormManager
                 $newFieldTranslation = $newField->getTranslation($fieldTranslation->getLocale(), true);
                 $newFieldTranslation->setTitle($fieldTranslation->getTitle());
                 $newFieldTranslation->setPlaceholder($fieldTranslation->getPlaceholder());
+                $newFieldTranslation->setHelp($fieldTranslation->getHelp());
                 $newFieldTranslation->setDefaultValue($fieldTranslation->getDefaultValue());
                 $newFieldTranslation->setShortTitle($fieldTranslation->getShortTitle());
                 $newFieldTranslation->setOptions($fieldTranslation->getOptions());
@@ -339,6 +340,7 @@ class FormManager
             $fieldTranslation = $field->getTranslation($locale, true);
             $fieldTranslation->setTitle(self::getValue($fieldData, 'title'));
             $fieldTranslation->setPlaceholder(self::getValue($fieldData, 'placeholder'));
+            $fieldTranslation->setHelp(self::getValue($fieldData, 'help'));
             $fieldTranslation->setDefaultValue(self::getValue($fieldData, 'defaultValue'));
             $fieldTranslation->setShortTitle(self::getValue($fieldData, 'shortTitle'));
             $fieldTranslation->setOptions(self::getValue($fieldData, 'options'));

--- a/Resources/config/doctrine/FormFieldTranslation.orm.xml
+++ b/Resources/config/doctrine/FormFieldTranslation.orm.xml
@@ -10,6 +10,7 @@
 
         <field name="title" column="title" type="text" nullable="true"/>
         <field name="placeholder" column="placeholder" type="string" length="255" nullable="true"/>
+        <field name="help" column="help" type="text"  nullable="true"/>
         <field name="defaultValue" column="defaultValue" type="text" nullable="true"/>
         <field name="shortTitle" column="shortTitle" type="string" length="255" nullable="true"/>
         <field name="locale" column="locale" type="string" length="5"/>

--- a/Resources/config/form-fields/default_field_extended.xml
+++ b/Resources/config/form-fields/default_field_extended.xml
@@ -19,4 +19,9 @@
             <title>sulu_form.choice</title>
         </meta>
     </property>
+    <property name="help" type="text_editor" colspan="12">
+        <meta>
+            <title>sulu_form.help</title>
+        </meta>
+    </property>
 </properties>

--- a/Resources/config/form-fields/field_attachment.xml
+++ b/Resources/config/form-fields/field_attachment.xml
@@ -34,4 +34,9 @@
             <title>sulu_form.attachment_max</title>
         </meta>
     </property>
+    <property name="help" type="text_editor" colspan="12">
+        <meta>
+            <title>sulu_form.help</title>
+        </meta>
+    </property>
 </properties>

--- a/Resources/config/form-fields/field_choices.xml
+++ b/Resources/config/form-fields/field_choices.xml
@@ -19,4 +19,9 @@
             <title>sulu_form.choice</title>
         </meta>
     </property>
+    <property name="help" type="text_editor" colspan="12">
+        <meta>
+            <title>sulu_form.help</title>
+        </meta>
+    </property>
 </properties>

--- a/Resources/config/form-fields/field_date.xml
+++ b/Resources/config/form-fields/field_date.xml
@@ -22,4 +22,9 @@
             <param name="type" value="toggler"/>
         </params>
     </property>
+    <property name="help" type="text_editor" colspan="12">
+        <meta>
+            <title>sulu_form.help</title>
+        </meta>
+    </property>
 </properties>

--- a/Resources/config/form-fields/field_example_default.xml
+++ b/Resources/config/form-fields/field_example_default.xml
@@ -14,4 +14,9 @@
             <title>sulu_form.default</title>
         </meta>
     </property>
+    <property name="help" type="text_editor" colspan="12">
+        <meta>
+            <title>sulu_form.help</title>
+        </meta>
+    </property>
 </properties>

--- a/Resources/translations/admin.de.json
+++ b/Resources/translations/admin.de.json
@@ -24,6 +24,7 @@
   "sulu_form.required": "Pflichtfeld",
   "sulu_form.width": "Breite",
   "sulu_form.example": "Beispiel",
+  "sulu_form.help": "Hilfetext",
   "sulu_form.default": "Standard",
   "sulu_form.short_title": "Kurztitel",
   "sulu_form.short_title_description": "Optionaler Titel des Feldes, z.B. in der Benachrichtigungs-Email.",

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -25,6 +25,7 @@
   "sulu_form.required": "Required field",
   "sulu_form.width": "Width",
   "sulu_form.example": "Example",
+  "sulu_form.help": "Help text",
   "sulu_form.default": "Default",
   "sulu_form.short_title": "Short title",
   "sulu_form.short_title_description": "Optional title of field, for example in notification mail.",

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -317,7 +317,7 @@ class FormControllerTest extends SuluTestCase
             $this->assertEquals('Placeholder', $response['fields'][$key]['placeholder']);
             $this->assertEquals('Default Value', $response['fields'][$key]['defaultValue']);
             $this->assertNotNull($response['fields'][$key]['options']);
-            $this->assertCountFields(11, $response['fields'][$key]);
+            $this->assertCountFields(12, $response['fields'][$key]);
         }
         // Receivers
         $this->assertCount(3, $response['receivers']);
@@ -398,6 +398,7 @@ class FormControllerTest extends SuluTestCase
         $formFieldTranslation->setShortTitle('Short Title');
         $formFieldTranslation->setTitle('Title');
         $formFieldTranslation->setPlaceholder('Placeholder');
+        $formFieldTranslation->setHelp('Help text');
         $formFieldTranslation->setDefaultValue('Default Value');
         $formFieldTranslation->setLocale('en');
         $formFieldTranslation->setOptions([]);
@@ -420,6 +421,7 @@ class FormControllerTest extends SuluTestCase
         $formFieldTranslation2->setShortTitle('Short Title');
         $formFieldTranslation2->setTitle('Title');
         $formFieldTranslation2->setPlaceholder('Placeholder');
+        $formFieldTranslation2->setHelp('Help text');
         $formFieldTranslation2->setDefaultValue('Default Value');
         $formFieldTranslation2->setLocale('en');
         $formFieldTranslation2->setOptions([]);
@@ -489,6 +491,7 @@ class FormControllerTest extends SuluTestCase
                     'title' => 'Title',
                     'shortTitle' => 'Short Title',
                     'placeholder' => 'Placeholder',
+                    'help' => 'Help text',
                     'defaultValue' => 'Default Value',
                     'width' => 'full',
                     'required' => true,
@@ -498,6 +501,7 @@ class FormControllerTest extends SuluTestCase
                     'title' => 'Title',
                     'shortTitle' => 'Short Title',
                     'placeholder' => 'Placeholder',
+                    'help' => 'Help text',
                     'defaultValue' => 'Default Value',
                     'width' => 'full',
                     'required' => true,

--- a/Tests/Functional/Mail/Fixtures/LoadFormFixture.php
+++ b/Tests/Functional/Mail/Fixtures/LoadFormFixture.php
@@ -56,6 +56,7 @@ class LoadFormFixture implements FixtureInterface
         $formFieldTranslation->setShortTitle('Short Title');
         $formFieldTranslation->setTitle('Title');
         $formFieldTranslation->setPlaceholder('Placeholder');
+        $formFieldTranslation->setHelp('Help text');
         $formFieldTranslation->setDefaultValue('Default Value');
         $formFieldTranslation->setLocale('de');
         $formFieldTranslation->setOptions([]);
@@ -78,6 +79,7 @@ class LoadFormFixture implements FixtureInterface
         $formFieldTranslation2->setShortTitle('Short Title');
         $formFieldTranslation2->setTitle('Title');
         $formFieldTranslation2->setPlaceholder('Placeholder');
+        $formFieldTranslation2->setHelp('Help text');
         $formFieldTranslation2->setDefaultValue('Default Value');
         $formFieldTranslation2->setLocale('de');
         $formFieldTranslation2->setOptions([]);

--- a/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
+++ b/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
@@ -190,7 +190,7 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
         $this->assertInstanceOf(FormMetadata::class, $attachment);
         $this->assertEquals('attachment', $attachment->getName());
         $this->assertEquals('Attachment', $attachment->getTitle());
-        $this->assertCount(6, $attachment->getItems());
+        $this->assertCount(7, $attachment->getItems());
 
         $this->arrayHasKey('required', $attachment->getItems());
         $this->assertEquals('Required field', $attachment->getItems()['required']->getLabel());

--- a/Tests/Functional/Trash/FormTrashItemHandlerTest.php
+++ b/Tests/Functional/Trash/FormTrashItemHandlerTest.php
@@ -120,6 +120,7 @@ class FormTrashItemHandlerTest extends SuluTestCase
         $formField1TranslationEn->setShortTitle('Short Title');
         $formField1TranslationEn->setTitle('Title');
         $formField1TranslationEn->setPlaceholder('Placeholder');
+        $formField1TranslationEn->setHelp('Help text');
         $formField1TranslationEn->setDefaultValue('Default Value');
         $formField1TranslationEn->setLocale('en');
         $formField1TranslationEn->setOptions([
@@ -132,6 +133,7 @@ class FormTrashItemHandlerTest extends SuluTestCase
         $formField1TranslationDe->setShortTitle('Kurzer Titel');
         $formField1TranslationDe->setTitle('Titel');
         $formField1TranslationDe->setPlaceholder('Platzhalter');
+        $formField1TranslationDe->setHelp('Help text');
         $formField1TranslationDe->setDefaultValue('Standardwert');
         $formField1TranslationDe->setLocale('de');
         $formField1TranslationDe->setOptions([]);
@@ -152,6 +154,7 @@ class FormTrashItemHandlerTest extends SuluTestCase
         $formField2Translation->setShortTitle('Short Title');
         $formField2Translation->setTitle('Title');
         $formField2Translation->setPlaceholder('Placeholder');
+        $formField2Translation->setHelp('Help text');
         $formField2Translation->setDefaultValue('Default Value');
         $formField2Translation->setLocale('en');
         $formField2Translation->setOptions([]);

--- a/Trash/FormTrashItemHandler.php
+++ b/Trash/FormTrashItemHandler.php
@@ -68,6 +68,7 @@ use Webmozart\Assert\Assert;
  *             title: string,
  *             locale: string,
  *             placeholder: string,
+ *             help: string,
  *             defaultValue: string,
  *             shortTitle: string,
  *             options: mixed[],
@@ -178,6 +179,7 @@ final class FormTrashItemHandler implements
                     'title' => $translation->getTitle(),
                     'locale' => $translation->getLocale(),
                     'placeholder' => $translation->getPlaceholder(),
+                    'help' => $translation->getHelp(),
                     'defaultValue' => $translation->getDefaultValue(),
                     'shortTitle' => $translation->getShortTitle(),
                     'options' => $translation->getOptions(),
@@ -254,6 +256,7 @@ final class FormTrashItemHandler implements
                 $fieldTranslation = $field->getTranslation($fieldTranslationData['locale'], true);
                 $fieldTranslation->setTitle($fieldTranslationData['title']);
                 $fieldTranslation->setPlaceholder($fieldTranslationData['placeholder']);
+                $fieldTranslation->setHelp($fieldTranslationData['help']);
                 $fieldTranslation->setDefaultValue($fieldTranslationData['defaultValue']);
                 $fieldTranslation->setShortTitle($fieldTranslationData['shortTitle']);
                 $fieldTranslation->setOptions($fieldTranslationData['options']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs | #344
| License | MIT

#### What's in this PR?

I have added the help property to the DynamicFormType. The field is displayed below the rest of the form fields. The field type is `text_editor` and the information is set to the `help` property of Symfony forms, with the `help_html` option enabled.

I tried to implement the property analog to placeholders. Feel free to look over it again thoroughly, I'll be honest, I haven't looked closely at the details of the whole implementation.

#### Why?

Editors can now add additional help text to form fields.

#### To Do

- [ ] Tests
- [ ] Create documentation
