### PR TITLE
Update SendingBlueEventListener to correctly send DoubleOpt-In emails

### DIFF
--- a/Event/SendinblueListSubscriber.php
+++ b/Event/SendinblueListSubscriber.php
@@ -82,7 +82,7 @@ class SendinblueListSubscriber implements EventSubscriberInterface
         $email = '';
         $firstName = '';
         $lastName = '';
-        $redirectionUrl = $request->getUriForPath('') . '?subscribe=true';
+        $redirectionUrl = $request->getUriForPath($request->getPathInfo()) . '?send=true&subscribe=true';
         $listIdsByMailTemplate = [];
 
         foreach ($form['fields'] as $field) {
@@ -121,7 +121,6 @@ class SendinblueListSubscriber implements EventSubscriberInterface
                     'firstname' => $firstName,
                     'lastname' => $lastName,
                 ],
-                'updateEnabled' => true,
             ]);
 
             $this->contactsApi->createDoiContact($createDoiContact);

--- a/Event/SendinblueListSubscriber.php
+++ b/Event/SendinblueListSubscriber.php
@@ -13,10 +13,8 @@ namespace Sulu\Bundle\FormBundle\Event;
 
 use GuzzleHttp\ClientInterface;
 use SendinBlue\Client\Api\ContactsApi;
-use SendinBlue\Client\ApiException;
 use SendinBlue\Client\Configuration;
 use SendinBlue\Client\Model\CreateDoiContact;
-use SendinBlue\Client\Model\UpdateContact;
 use Sulu\Bundle\FormBundle\Entity\Dynamic;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -113,44 +111,6 @@ class SendinblueListSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $contact = null;
-        try {
-            $contact = $this->contactsApi->getContactInfo($email);
-        } catch (ApiException $e) {
-            if (404 !== $e->getCode()) {
-                throw $e;
-            }
-            // Contact does not exist, ignore the exception
-        }
-
-        if (null !== $contact) {
-            $updateContact = new UpdateContact();
-
-            $updateContact->setAttributes(
-                (object) \array_replace(
-                    (array) $contact->getAttributes(),
-                    [
-                        'FIRST_NAME' => $firstName,
-                        'LAST_NAME' => $lastName,
-                    ]
-                )
-            );
-
-            /** @var int[] $collectedListIds */
-            $collectedListIds = $contact->getListIds();
-            foreach ($listIdsByMailTemplate as $mailTemplateId => $listIds) {
-                $collectedListIds = \array_merge($collectedListIds, $listIds);
-            }
-
-            $collectedListIds = \array_unique($collectedListIds);
-
-            $updateContact->setListIds($collectedListIds);
-
-            $this->contactsApi->updateContact($email, $updateContact);
-
-            return;
-        }
-
         foreach ($listIdsByMailTemplate as $mailTemplateId => $listIds) {
             $createDoiContact = new CreateDoiContact([
                 'email' => $email,
@@ -158,9 +118,10 @@ class SendinblueListSubscriber implements EventSubscriberInterface
                 'includeListIds' => $listIds,
                 'redirectionUrl' => $redirectionUrl,
                 'attributes' => [
-                    'FIRST_NAME' => $firstName,
-                    'LAST_NAME' => $lastName,
+                    'firstname' => $firstName,
+                    'lastname' => $lastName,
                 ],
+                'updateEnabled' => true,
             ]);
 
             $this->contactsApi->createDoiContact($createDoiContact);

--- a/Tests/Unit/Event/SendinblueListSubscriberTest.php
+++ b/Tests/Unit/Event/SendinblueListSubscriberTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\RequestInterface;
-use SendinBlue\Client\ApiException;
 use Sulu\Bundle\FormBundle\Configuration\FormConfiguration;
 use Sulu\Bundle\FormBundle\Entity\Dynamic;
 use Sulu\Bundle\FormBundle\Entity\Form;
@@ -78,12 +77,6 @@ class SendinblueListSubscriberTest extends TestCase
             /** @var RequestInterface $request */
             $request = $args[0];
 
-            if ('https://api.sendinblue.com/v3/contacts/john.doe%40example.org' === $request->getUri()->__toString()) {
-                $self->assertSame('GET', $request->getMethod());
-
-                throw new ApiException('', 404);
-            }
-
             if ('https://api.sendinblue.com/v3/contacts/doubleOptinConfirmation' === $request->getUri()->__toString()) {
                 $self->assertSame('POST', $request->getMethod());
 
@@ -92,12 +85,13 @@ class SendinblueListSubscriberTest extends TestCase
                 $self->assertSame([
                     'email' => 'john.doe@example.org',
                     'attributes' => [
-                        'FIRST_NAME' => 'John',
-                        'LAST_NAME' => 'Doe',
+                        'firstname' => 'John',
+                        'lastname' => 'Doe',
                     ],
                     'includeListIds' => ['789'],
                     'templateId' => 456,
                     'redirectionUrl' => 'http://localhost?subscribe=true',
+                    'updateEnable' => true,
                 ], $json);
 
                 return new Response();
@@ -105,54 +99,7 @@ class SendinblueListSubscriberTest extends TestCase
 
             throw new \RuntimeException('Unexpected request: ' . $request->getUri()->__toString());
         })
-            ->shouldBeCalledTimes(2);
-
-        // act
-        $this->sendinblueListSubscriber->listSubscribe($event);
-
-        $this->assertTrue(true);
-    }
-
-    public function testlistSubscribeAlreadyExist(): void
-    {
-        $this->requestStack->push(Request::create('http://localhost/', 'POST'));
-        $event = $this->createFormSavePostEvent();
-
-        $self = $this;
-        $this->client->send(Argument::cetera())->will(function($args) use ($self) {
-            /** @var RequestInterface $request */
-            $request = $args[0];
-
-            if ('https://api.sendinblue.com/v3/contacts/john.doe%40example.org' === $request->getUri()->__toString()
-                && 'GET' === $request->getMethod()
-            ) {
-                return new Response(200, ['Content-Type' => 'application/json'], \json_encode([
-                    'id' => 123,
-                    'email' => 'john.doe@example.org',
-                    'attributes' => [],
-                    'listIds' => [],
-                ]));
-            }
-
-            if ('https://api.sendinblue.com/v3/contacts/john.doe%40example.org' === $request->getUri()->__toString()
-                && 'PUT' === $request->getMethod()
-            ) {
-                $json = \json_decode($request->getBody()->getContents(), true);
-
-                $self->assertSame([
-                    'attributes' => [
-                        'FIRST_NAME' => 'John',
-                        'LAST_NAME' => 'Doe',
-                    ],
-                    'listIds' => ['789'],
-                ], $json);
-
-                return new Response();
-            }
-
-            throw new \RuntimeException('Unexpected request (' . $request->getMethod() . '): ' . $request->getUri()->__toString());
-        })
-            ->shouldBeCalledTimes(2);
+            ->shouldBeCalledOnce();
 
         // act
         $this->sendinblueListSubscriber->listSubscribe($event);

--- a/Tests/Unit/Event/SendinblueListSubscriberTest.php
+++ b/Tests/Unit/Event/SendinblueListSubscriberTest.php
@@ -69,7 +69,7 @@ class SendinblueListSubscriberTest extends TestCase
 
     public function testlistSubscribeNotExist(): void
     {
-        $this->requestStack->push(Request::create('http://localhost/', 'POST'));
+        $this->requestStack->push(Request::create('http://localhost/newsletter', 'POST'));
         $event = $this->createFormSavePostEvent();
 
         $self = $this;
@@ -90,8 +90,7 @@ class SendinblueListSubscriberTest extends TestCase
                     ],
                     'includeListIds' => ['789'],
                     'templateId' => 456,
-                    'redirectionUrl' => 'http://localhost?subscribe=true',
-                    'updateEnable' => true,
+                    'redirectionUrl' => 'http://localhost/newsletter?send=true&subscribe=true',
                 ], $json);
 
                 return new Response();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Explain the contents of the PR.

#### Why?

https://github.com/sulu/SuluFormBundle/pull/348 fixed the error, but introduced an unexpected behaviour. The user was updated directly and for already registered users, no DOI email was sent by sendinblue.

~~This PR adds the `updateEnabled` flag, therefore the DOI is still sent and already existing users are updated.~~ Update: the `updateEnabled` flag was never send and Today SendingBlue fixed the issue.
Furthermore the PR uses the normalized attributes `firstname` and `lastname` for the additional data.

