### PR TITLE
dynamic forms: data detail view

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,27 @@
+[options]
+types_first=false
+esproposal.decorators=ignore
+esproposal.optional_chaining=enable
+module.name_mapper='.+\.s?css' -> 'empty/object'
+module.name_mapper='fos-jsrouting/router' -> 'empty/object'
+
+[untyped]
+.*/node_modules/react-leaflet/.*
+
+[ignore]
+.*/node_modules/bower-json/.*
+.*/node_modules/config-chain/.*
+.*/node_modules/findup/.*
+.*/node_modules/jss/.*
+.*/node_modules/npmconf/.*
+.*/node_modules/stylelint/.*
+.*/node_modules/resolve/test/resolver/malformed_package_json/.*
+.*/vendor/symfony/.*
+
+.git/
+.github/
+bin/
+config/
+public/
+templates/
+var/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ bower_components/
 .sass-cache/
 node_modules/
 npm-debug.log
+package-lock.json
+yarn.lock
 
 # tests
 /Tests/Application/*.local

--- a/Admin/FormAdmin.php
+++ b/Admin/FormAdmin.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ListItemAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -78,7 +79,7 @@ class FormAdmin extends Admin
     {
         $formLocales = \array_values(
             \array_map(
-                function(Localization $localization) {
+                static function(Localization $localization) {
                     return $localization->getLocale();
                 },
                 $this->webspaceManager->getAllLocalizations()
@@ -155,7 +156,19 @@ class FormAdmin extends Admin
                 ->addRouterAttributesToListRequest(['id' => 'form'])
                 ->addRouterAttributesToListMetadata(['id' => 'id'])
                 ->addToolbarActions($dataListToolbarActions)
+                ->addItemActions([
+                    new ListItemAction('sulu_form.dynamic_preview_item_action'),
+                ])
                 ->setParent(static::EDIT_FORM_VIEW)
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory->createViewBuilder(
+                'sulu_form.edit_form.data_details',
+                '/forms/:locale/:formId/data/details/:id',
+                'sulu_form.dynamic_preview'
+            )
+                ->setOption('dataListView', static::LIST_VIEW_DATA)
+                ->setOption('dataResourceKey', 'dynamic_forms')
         );
     }
 

--- a/Resources/js/index.js
+++ b/Resources/js/index.js
@@ -1,0 +1,8 @@
+// @flow
+import {listItemActionRegistry} from 'sulu-admin-bundle/views';
+import {viewRegistry} from 'sulu-admin-bundle/containers';
+import DynamicPreview from './views/DynamicPreview';
+import DynamicPreviewItemAction from './listItemActions/DynamicPreviewItemAction';
+
+listItemActionRegistry.add('sulu_form.dynamic_preview_item_action', DynamicPreviewItemAction);
+viewRegistry.add('sulu_form.dynamic_preview', DynamicPreview);

--- a/Resources/js/listItemActions/DynamicPreviewItemAction.js
+++ b/Resources/js/listItemActions/DynamicPreviewItemAction.js
@@ -1,0 +1,22 @@
+// @flow
+import {AbstractListItemAction} from 'sulu-admin-bundle/views';
+
+export default class DynamicPreviewItemAction extends AbstractListItemAction {
+  getItemActionConfig(item: ?Object) {
+    return {
+      icon: 'su-eye',
+      disabled: false,
+      onClick: item ? () => this.handleClick(item) : undefined,
+    };
+  }
+
+  handleClick = (item) => {
+    this.router.navigate(
+      'sulu_form.edit_form.data_details',
+      {
+        formId: this.listStore.metadataOptions.id,
+        id: item.id
+      }
+    )
+  };
+}

--- a/Resources/js/package.json
+++ b/Resources/js/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "sulu-forms-bundle",
+    "description": "Adds support for forms to Sulu",
+    "license": "MIT",
+    "repository": "https://github.com/sulu/sulu.git",
+    "devDependencies": {
+        "sulu-admin-bundle": "file:../../vendor/sulu/sulu/src/Sulu/Bundle/AdminBundle/Resources/js"
+    },
+    "peerDependencies": {
+        "mobx": "^4.0.0",
+        "mobx-react": "^5.0.0",
+        "react": "^16.2.0 || ^17.0.0",
+        "sulu-admin-bundle": "*"
+    }
+}

--- a/Resources/js/package.json
+++ b/Resources/js/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sulu-forms-bundle",
+    "name": "sulu-form-bundle",
     "description": "Adds support for forms to Sulu",
     "license": "MIT",
     "repository": "https://github.com/sulu/sulu.git",

--- a/Resources/js/views/DynamicPreview.js
+++ b/Resources/js/views/DynamicPreview.js
@@ -1,0 +1,92 @@
+// @flow
+import React from 'react';
+import {observer} from 'mobx-react';
+import {action, observable} from 'mobx';
+import {Loader} from 'sulu-admin-bundle/components';
+import Snackbar from 'sulu-admin-bundle/components/Snackbar';
+import {withToolbar} from 'sulu-admin-bundle/containers';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+
+@observer
+class DynamicPreview extends React.Component {
+  @observable loading = false;
+  @observable data = undefined;
+
+  componentDidMount() {
+    this.loadData();
+  }
+
+  @action loadData = () => {
+    this.loading = true;
+    this.data = undefined;
+
+    const dataResourceKey = this.props.router.route.options.dataResourceKey;
+
+    return ResourceRequester.get(dataResourceKey, {id: this.getDataId()})
+      .then(action(response => {
+        console.log('RESPONSE', response);
+        this.data = response;
+      }))
+      .catch(e => {
+        console.error('Error while loading dynamic form data from server.', e);
+      })
+      .finally(action(() => {
+        this.loading = false;
+      }));
+  }
+
+  @action navigateToFormData = () => {
+    const routeAttributes = this.props.router.attributes;
+    this.props.router.navigate(
+      this.props.router.route.options.dataListView,
+      {
+        locale: routeAttributes.locale,
+        id: routeAttributes.formId,
+      }
+    )
+  }
+
+  getDataId() {
+    return this.props.router.attributes.id;
+  }
+
+  render() {
+    if (this.loading) {
+      return <Loader/>;
+    }
+
+    if (!this.data) {
+      return <Snackbar message="No data found!" type="error"/>
+    }
+
+    return (
+      <div>
+        <h1>Form submission from {this.data.typeName}</h1>
+        <small>Submitted at: {this.data.created}</small>
+        <dl>
+        {Object.keys(this.data.data).map((key, index) => (
+          <React.Fragment key={index}>
+            <dt>{key}</dt>
+            <dd>{this.data.data[key]}</dd>
+          </React.Fragment>
+        ))}
+        </dl>
+      </div>
+    );
+  }
+}
+
+export default withToolbar(DynamicPreview, function () {
+  return {
+    items: [
+      {
+        type: 'button',
+        icon: 'su-angle-left',
+        disabled: false,
+        onClick: () => {
+          this.navigateToFormData();
+        },
+      }
+    ]
+  };
+});

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,11 +171,6 @@ parameters:
 			path: Controller/DynamicController.php
 
 		-
-			message: "#^Cannot call method getFieldsByType\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\|null\\.$#"
-			count: 1
-			path: Controller/DynamicController.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: Controller/DynamicController.php
@@ -192,11 +187,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$dynamics of method Sulu\\\\Bundle\\\\FormBundle\\\\ListBuilder\\\\DynamicListFactory\\:\\:build\\(\\) expects array\\<Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\>, array given\\.$#"
-			count: 1
-			path: Controller/DynamicController.php
-
-		-
-			message: "#^Parameter \\#1 \\$entity of method Doctrine\\\\ORM\\\\EntityManager\\:\\:remove\\(\\) expects object, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\|null given\\.$#"
 			count: 1
 			path: Controller/DynamicController.php
 
@@ -1704,4 +1694,3 @@ parameters:
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\RequestStack\\:\\:getMasterRequest\\(\\)\\.$#"
 			count: 1
 			path: TitleProvider/StructureTitleProvider.php
-


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | no
| Related issues/PRs | no
| License | MIT

#### What's in this PR?

One of my client wants to have a detail view of dynamic form submissions, because he doesn't want to export everything, but check the submissions from the Sulu Backend. If some text-editor field values are too long, the Table component just hides the text.

#### Why?

As I'm still pretty new to Sulu, maybe there is another, easier solution, without touching the admin frontend. So this PR is **more of a PoC and open for discussion**.

I didn't find an actual "view" or "readonly form" mode in Sulu, so I tried this approach.

#### Example Usage

Read-Only View:  
![Bildschirm­foto 2023-02-24 um 13 08 44](https://user-images.githubusercontent.com/1265783/221175773-9da03742-93d8-4236-ba0b-567cd718b14d.png)

Preview Button in list:  
![image](https://user-images.githubusercontent.com/1265783/221175935-e3757b47-2687-4b0b-a5e0-f607fad28f54.png)


#### BC Breaks/Deprecations

It adds admin frontend code

#### To Do

- [ ] Discuss better solution
- [ ] Field mappings
- [ ] Attachments
- [ ] Create documentation

