### PR TITLE
Fix list heading does not fallback to default locale

### DIFF
--- a/ListBuilder/DynamicListFactory.php
+++ b/ListBuilder/DynamicListFactory.php
@@ -55,7 +55,7 @@ class DynamicListFactory implements DynamicListFactoryInterface
             }
 
             $title = '';
-            $translation = $field->getTranslation($locale);
+            $translation = $field->getTranslation($locale, false, true);
 
             if ($translation) {
                 $title = $translation->getShortTitle() ?: \strip_tags($translation->getTitle());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR fixes the heading of form listings that show the field keys instead of their labels. This happens when the form is not localised in the admin's language.

#### Why?
We have a form that is localized in italian only. But our admin account use english as preferred language:

The first image shows the listing without the fix:
![nok](https://user-images.githubusercontent.com/89986734/233939439-fb240226-98ae-4f35-92cb-503d64402c54.jpg)

The second one with the fix:
![ok](https://user-images.githubusercontent.com/89986734/233939437-555a3399-651f-4f89-b00a-2280de756a01.jpg)
