### PR TITLE
Fix DynamicController dynamicListFactory build arguments order

### DIFF
--- a/Controller/DynamicController.php
+++ b/Controller/DynamicController.php
@@ -85,6 +85,7 @@ class DynamicController implements ClassResourceInterface
      */
     public function cgetAction(Request $request): Response
     {
+        $locale = $this->getLocale($request);
         $filters = $this->getFilters($request);
         $page = $request->get('page', 1);
         $limit = $request->get('limit');
@@ -100,7 +101,7 @@ class DynamicController implements ClassResourceInterface
             $offset
         );
 
-        $entries = $this->dynamicListFactory->build($entries, $view);
+        $entries = $this->dynamicListFactory->build($entries, $locale, $view);
 
         // avoid total request when entries < limit
         if (\count($entries) == $limit) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| License | MIT

#### What's in this PR?

DynamicController is passing arguments to the build method of the dynamicListFactory property in the wrong order. The locale should be passed as the second argument, and the builder alias as the third.