### PR TITLE
Adds an option to export CSV with labels as heading

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -145,6 +145,10 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('dynamic_disabled_types')
                 ->prototype('scalar')->end()->defaultValue([])
             ->end()
+            ->booleanNode('dynamic_labeled_exports')
+                ->info('Prefers labels instead of fields key as headings during export.')
+                ->defaultFalse()
+            ->end()
         ;
 
         return $treeBuilder;

--- a/DependencyInjection/SuluFormExtension.php
+++ b/DependencyInjection/SuluFormExtension.php
@@ -151,6 +151,7 @@ class SuluFormExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_form.media_collection_strategy', $mediaCollectionStrategy);
         $container->setParameter('sulu_form.static_forms', $config['static_forms']);
         $container->setParameter('sulu_form.dynamic_disabled_types', $config['dynamic_disabled_types']);
+        $container->setParameter('sulu_form.dynamic_labeled_exports', $config['dynamic_labeled_exports']);
 
         // Default Media Collection Strategy
         $container->setAlias(

--- a/ListBuilder/DynamicLabeledListBuilder.php
+++ b/ListBuilder/DynamicLabeledListBuilder.php
@@ -38,7 +38,7 @@ class DynamicLabeledListBuilder extends DynamicListBuilder
 
     private function getLabels(Form $form, string $locale): array
     {
-        if (!isset($formFieldsLabelCache[$form->getId()])) {
+        if (!isset($this->formFieldsLabelCache[$form->getId()])) {
             $labels = [];
 
             foreach ($form->getFields() as $field) {
@@ -52,9 +52,9 @@ class DynamicLabeledListBuilder extends DynamicListBuilder
                 $labels[$field->getKey()] = $label;
             }
 
-            $formFieldsLabelCache[$form->getId()] = $labels;
+            $this->formFieldsLabelCache[$form->getId()] = $labels;
         }
 
-        return $formFieldsLabelCache[$form->getId()];
+        return $this->formFieldsLabelCache[$form->getId()];
     }
 }

--- a/ListBuilder/DynamicLabeledListBuilder.php
+++ b/ListBuilder/DynamicLabeledListBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\ListBuilder;
+
+use Sulu\Bundle\FormBundle\Entity\Dynamic;
+use Sulu\Bundle\FormBundle\Entity\Form;
+
+class DynamicLabeledListBuilder extends DynamicListBuilder
+{
+    private $formFieldsLabelCache = [];
+
+    public function build(Dynamic $dynamic, string $locale): array
+    {
+        $entry = parent::build($dynamic, $locale);
+
+        if (empty($entry)) {
+            return $entry;
+        }
+
+        $labels = $this->getLabels($dynamic->getForm(), $locale);
+        $entryLabeled = [];
+
+        foreach ($entry[0] as $key => $value) {
+            $entryLabeled[$labels[$key] ?? $key] = $value;
+        }
+
+        return [$entryLabeled];
+    }
+
+    private function getLabels(Form $form, string $locale): array
+    {
+        if (!isset($formFieldsLabelCache[$form->getId()])) {
+            $labels = [];
+
+            foreach ($form->getFields() as $field) {
+                $label = '';
+                $translation = $field->getTranslation($locale, false, true);
+
+                if ($translation) {
+                    $label = $translation->getShortTitle() ?: \strip_tags($translation->getTitle());
+                }
+
+                $labels[$field->getKey()] = $label;
+            }
+
+            $formFieldsLabelCache[$form->getId()] = $labels;
+        }
+
+        return $formFieldsLabelCache[$form->getId()];
+    }
+}

--- a/ListBuilder/DynamicLabeledListBuilder.php
+++ b/ListBuilder/DynamicLabeledListBuilder.php
@@ -16,7 +16,7 @@ use Sulu\Bundle\FormBundle\Entity\Form;
 
 class DynamicLabeledListBuilder extends DynamicListBuilder
 {
-    private $formFieldsLabelCache = [];
+    private array $formFieldsLabelCache = [];
 
     public function build(Dynamic $dynamic, string $locale): array
     {
@@ -42,14 +42,16 @@ class DynamicLabeledListBuilder extends DynamicListBuilder
             $labels = [];
 
             foreach ($form->getFields() as $field) {
-                $label = '';
+                if (\in_array($field->getType(), Dynamic::$HIDDEN_TYPES)) {
+                    continue;
+                }
+
                 $translation = $field->getTranslation($locale, false, true);
 
                 if ($translation) {
                     $label = $translation->getShortTitle() ?: \strip_tags($translation->getTitle());
+                    $labels[$field->getKey()] = $label;
                 }
-
-                $labels[$field->getKey()] = $label;
             }
 
             $this->formFieldsLabelCache[$form->getId()] = $labels;

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -120,6 +120,14 @@
             <tag name="sulu_form.dynamic_list_builder" alias="simple" />
         </service>
 
+        <service id="sulu_form.list_builder.dynamic_labeled_list_builder"
+                 class="Sulu\Bundle\FormBundle\ListBuilder\DynamicLabeledListBuilder">
+            <argument>%sulu_form.dynamic_list_builder.delimiter%</argument>
+            <argument type="service" id="router" />
+
+            <tag name="sulu_form.dynamic_list_builder" alias="labeled" />
+        </service>
+
         <!-- Repositories -->
         <service id="sulu_form.repository.form" class="Sulu\Bundle\FormBundle\Repository\FormRepository">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
@@ -197,6 +205,7 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="sulu_form.repository.form"/>
             <argument type="service" id="fos_rest.view_handler"/>
+            <argument>%sulu_form.dynamic_labeled_exports%</argument>
         </service>
 
         <!-- Form Controller -->

--- a/Resources/doc/dynamic.md
+++ b/Resources/doc/dynamic.md
@@ -241,6 +241,14 @@ sulu_form:
         protected: true
 ```
 
+## Export to CSV with labels as heading
+By default, forms are exported with the first row filled with the field keys. Enable the following option to fill it with field labels instead:
+
+```yml
+sulu_form:
+    dynamic_labeled_exports: true
+```
+
 ## Test Checklist
 
 The following things you should check when implement the dynamic form type on your website.


### PR DESCRIPTION
| Q | A
| --- | ---
| New feature? | yes
| Related issues/PRs | #359
| License | MIT

#### What's in this PR?

When exporting forms to CSV, the first row is filled with the field keys. This may be the preferable option if the CSV is to be read by a machine. However, if the CSV is to be processed by a human, a label is more helpful to distinguish the columns.
This PR adds an option to the sulu_form configuration to choose between the two formats.

With the option disabled (same as before):
![nok](https://user-images.githubusercontent.com/89986734/233945055-224a4a09-06df-4c10-84fe-eb0958b06328.jpg)

With the option enabled:
![ok](https://user-images.githubusercontent.com/89986734/233945058-2c3eb70a-e196-4cae-aa96-44a651447641.jpg)