### PR TITLE
Load fallback translation after form copy

### DIFF
--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -153,7 +153,7 @@ class FormManager
         }
 
         /** @var FormTranslation $newFormTranslation */
-        $newFormTranslation = $newForm->getTranslation($locale);
+        $newFormTranslation = $newForm->getTranslation($locale, false, true);
 
         $this->domainEventCollector->collect(
             new FormCopiedEvent(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixes an error which occurs on form copy when the user locale does not exist.

#### Why?

Forms could not be copied when the translation for the user was not existing.

