### PR TITLE
Support doctrine/persistence ^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.2 || ^8.0",
         "doctrine/collections": "^1.0",
         "doctrine/orm": "^2.5.3",
-        "doctrine/persistence": "^1.3 || ^2.0",
+        "doctrine/persistence": "^1.3 || ^2.0 || ^3.0",
         "sulu/sulu": "^2.4.1 || ^2.5.0@dev",
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/console": "^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | /
| Related issues/PRs | /
| License | MIT

#### What's in this PR?

To run Sulu with this bundle on Symfony 6.4, one of the constrained packages was `doctrine/persistence`, which was still locked to ^2 here, while ^3 is required.

I went through the upgrade notes on https://github.com/doctrine/persistence/blob/3.4.x/UPGRADE.md. This bundle does not seem to be affected by any BC breaking changes.

**Note:** Linting errors do not seem to be caused by this PR.

#### Why?

Move towards supporting Symfony 6.4

#### BC Breaks/Deprecations

There should be none.
