### PR TITLE
Fix copy block and duplicate of form fields

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,6 +31,8 @@ $config->setRiskyAllowed(true)
         'phpdoc_types_order' => false,
         'single_line_throw' => false,
         'single_line_comment_spacing' => false,
+        'nullable_type_declaration_for_default_null_value' => false,
+        'no_superfluous_phpdoc_tags' => false,
     ])
     ->setFinder($finder);
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,8 +31,6 @@ $config->setRiskyAllowed(true)
         'phpdoc_types_order' => false,
         'single_line_throw' => false,
         'single_line_comment_spacing' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
-        'no_superfluous_phpdoc_tags' => false,
     ])
     ->setFinder($finder);
 

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -378,8 +378,6 @@ class FormManager
             }
         }
 
-        exit;
-
         // Remove Fields
         foreach ($form->getFieldsNotInArray($reservedKeys) as $deletedField) {
             $form->removeField($deletedField);

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -306,11 +306,32 @@ class FormManager
      */
     protected function updateFields(array $data, Form $form, string $locale): void
     {
-        $reservedKeys = \array_column(self::getValue($data, 'fields', []), 'key');
+        $fields = self::getValue($data, 'fields', []);
+
+        $existingIds = [];
+        $existingKeys = [];
+        foreach ($fields as $key => $fieldData) { // make id and keys unique when block get copied
+             if (\in_array($fieldData['id'] ?? null, $existingIds)) {
+                  unset($fields[$key]['id']);
+             }
+             if (\in_array($fieldData['key'] ?? null, $existingKeys)) {
+                  unset($fields[$key]['key']);
+             }
+
+             if (isset($fieldData['id'])) {
+                 $existingIds[] = $fieldData['id'];
+             }
+
+             if (isset($fieldData['key'])) {
+                 $existingKeys[] = $fieldData['key'];
+             }
+        }
+
+        $reservedKeys = \array_column($fields, 'key');
 
         $counter = 0;
 
-        foreach (self::getValue($data, 'fields', []) as $fieldData) {
+        foreach ($fields as $fieldData) {
             ++$counter;
             $fieldType = self::getValue($fieldData, 'type');
             $fieldKey = self::getValue($fieldData, 'key');
@@ -356,6 +377,8 @@ class FormManager
                 $form->addField($field);
             }
         }
+
+        exit;
 
         // Remove Fields
         foreach ($form->getFieldsNotInArray($reservedKeys) as $deletedField) {

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -273,6 +273,7 @@ class FormManager
     {
         $receiversRepository = $this->entityManager->getRepository(FormTranslationReceiver::class);
         $receiverDatas = self::getValue($data, 'receivers', []);
+        \assert(\is_array($receiverDatas), 'Receivers must be an array.');
 
         // Remove old receivers.
         $oldReceivers = $receiversRepository->findBy(['formTranslation' => $translation]);
@@ -307,6 +308,7 @@ class FormManager
     protected function updateFields(array $data, Form $form, string $locale): void
     {
         $fields = self::getValue($data, 'fields', []);
+        \assert(\is_array($fields), 'Fields must be an array.');
 
         $existingIds = [];
         $existingKeys = [];

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -311,20 +311,20 @@ class FormManager
         $existingIds = [];
         $existingKeys = [];
         foreach ($fields as $key => $fieldData) { // make id and keys unique when block get copied
-             if (\in_array($fieldData['id'] ?? null, $existingIds)) {
-                  unset($fields[$key]['id']);
-             }
-             if (\in_array($fieldData['key'] ?? null, $existingKeys)) {
-                  unset($fields[$key]['key']);
-             }
+            if (\in_array($fieldData['id'] ?? null, $existingIds)) {
+                unset($fields[$key]['id']);
+            }
+            if (\in_array($fieldData['key'] ?? null, $existingKeys)) {
+                unset($fields[$key]['key']);
+            }
 
-             if (isset($fieldData['id'])) {
-                 $existingIds[] = $fieldData['id'];
-             }
+            if (isset($fieldData['id'])) {
+                $existingIds[] = $fieldData['id'];
+            }
 
-             if (isset($fieldData['key'])) {
-                 $existingKeys[] = $fieldData['key'];
-             }
+            if (isset($fieldData['key'])) {
+                $existingKeys[] = $fieldData['key'];
+            }
         }
 
         $reservedKeys = \array_column($fields, 'key');

--- a/Manager/FormManager.php
+++ b/Manager/FormManager.php
@@ -337,6 +337,7 @@ class FormManager
             ++$counter;
             $fieldType = self::getValue($fieldData, 'type');
             $fieldKey = self::getValue($fieldData, 'key');
+
             $field = $form->getField($fieldKey);
             $uniqueKey = $this->getUniqueKey($fieldType, $reservedKeys);
 
@@ -347,10 +348,12 @@ class FormManager
             if (!$field) {
                 $field = new FormField();
                 $field->setKey($uniqueKey);
-                $reservedKeys[] = $uniqueKey;
             } elseif ($field->getType() !== $fieldType || !$field->getKey()) {
                 $field->setKey($uniqueKey);
-                $reservedKeys[] = $uniqueKey;
+            }
+
+            if (!\in_array($field->getKey(), $reservedKeys)) {
+                $reservedKeys[] = $field->getKey();
             }
 
             $field->setOrder($counter);

--- a/Tests/Application/.env
+++ b/Tests/Application/.env
@@ -1,4 +1,4 @@
 APP_ENV=test
-DATABASE_URL=mysql://root@127.0.0.1:3306/su_form_test?serverVersion=5.7
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/su_form_test?serverVersion=5.7
 DATABASE_CHARSET=utf8mb4
 DATABASE_COLLATE=utf8mb4_unicode_ci

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -239,7 +239,7 @@ class FormControllerTest extends SuluTestCase
                         'required' => true,
                     ],
                     [
-                        'key' => 'email', // we are testing here if second email field is correctly created as email2
+                        'key' => 'email', // we are testing here if third email field is correctly created as email2
                         'type' => 'email',
                         'title' => 'Title',
                         'shortTitle' => 'Short Title',

--- a/Tests/Functional/Controller/FormControllerTest.php
+++ b/Tests/Functional/Controller/FormControllerTest.php
@@ -206,6 +206,79 @@ class FormControllerTest extends SuluTestCase
         $this->assertFullForm($response);
     }
 
+    public function testPutDuplicatedField(): void
+    {
+        $form = $this->createFullForm();
+        $this->client->request(
+            'PUT',
+            '/admin/api/forms/' . $form->getId(),
+            [
+                'locale' => 'en',
+                'title' => 'Title',
+                'toEmail' => 'testing@example.com',
+                'fromEmail' => 'testing@example.com',
+                'fields' => [
+                    [
+                        'key' => 'email',
+                        'type' => 'email',
+                        'title' => 'Title',
+                        'shortTitle' => 'Short Title',
+                        'placeholder' => 'Placeholder',
+                        'defaultValue' => 'Default Value',
+                        'width' => 'full',
+                        'required' => true,
+                    ],
+                    [
+                        'key' => 'email', // we are testing here if second email field is correctly interpreted as email1
+                        'type' => 'email',
+                        'title' => 'Title',
+                        'shortTitle' => 'Short Title',
+                        'placeholder' => 'Placeholder',
+                        'defaultValue' => 'Default Value',
+                        'width' => 'full',
+                        'required' => true,
+                    ],
+                    [
+                        'key' => 'email', // we are testing here if second email field is correctly created as email2
+                        'type' => 'email',
+                        'title' => 'Title',
+                        'shortTitle' => 'Short Title',
+                        'placeholder' => 'Placeholder',
+                        'defaultValue' => 'Default Value',
+                        'width' => 'full',
+                        'required' => true,
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $respondedFields = [];
+        foreach ($response['fields'] ?? [] as $field) {
+            $respondedFields[] = [
+                'key' => $field['key'],
+                'type' => $field['type'],
+            ];
+        }
+
+        $this->assertSame([
+            [
+                'key' => 'email',
+                'type' => 'email',
+            ],
+            [
+                'key' => 'email1',
+                'type' => 'email',
+            ],
+            [
+                'key' => 'email2',
+                'type' => 'email',
+            ],
+        ], $respondedFields);
+    }
+
     public function testPutNotExist(): void
     {
         $this->client->request(

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.3.2",
         "jangregor/phpstan-prophecy": "^1.0",
         "massive/search-bundle": "^2.0",
-        "php-cs-fixer/shim": "^3.57",
+        "php-cs-fixer/shim": "^3.0",
         "phpspec/prophecy": "^1.14",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-doctrine": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1141,26 +1141,6 @@ parameters:
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 2
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot access offset 'email' on mixed\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot access offset 'name' on mixed\\.$#"
-			count: 2
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot access offset 'type' on mixed\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
 			message: "#^Cannot call method getId\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
 			count: 1
 			path: Manager/FormManager.php
@@ -1286,27 +1266,12 @@ parameters:
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_column expects array, mixed given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$data of static method Sulu\\\\Bundle\\\\FormBundle\\\\Manager\\\\FormManager\\:\\:getValue\\(\\) expects array, mixed given\\.$#"
-			count: 9
-			path: Manager/FormManager.php
-
-		-
 			message: "#^Parameter \\#1 \\$datetime of class DateTime constructor expects string, mixed given\\.$#"
 			count: 1
 			path: Manager/FormManager.php
 
 		-
 			message: "#^Parameter \\#1 \\$defaultLocale of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:setDefaultLocale\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$email of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslationReceiver\\:\\:setEmail\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: Manager/FormManager.php
 
@@ -1323,11 +1288,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:getTranslation\\(\\) expects string, string\\|null given\\.$#"
 			count: 3
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslationReceiver\\:\\:setName\\(\\) expects string, mixed given\\.$#"
-			count: 1
 			path: Manager/FormManager.php
 
 		-
@@ -1351,22 +1311,12 @@ parameters:
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslationReceiver\\:\\:setType\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
 			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Bundle\\\\FormBundle\\\\Manager\\\\FormManager\\:\\:getUniqueKey\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: Manager/FormManager.php
 
 		-
 			message: "#^Parameter \\#1 \\$width of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormField\\:\\:setWidth\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
 			count: 1
 			path: Manager/FormManager.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #336
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Fix copy block for form manager

#### Why?

Currently copied field get removed as the same key is copied and key is used to find the field. If now multiple fields with the same key are copied we will ignore the second field and give it a new field.

