### PR TITLE
Fix disable required constraint for freetext and headline field

### DIFF
--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\FormBundle\Form\Type;
 
 use Sulu\Bundle\FormBundle\Dynamic\Checksum;
 use Sulu\Bundle\FormBundle\Dynamic\FormFieldTypePool;
+use Sulu\Bundle\FormBundle\Dynamic\Types\FreeTextType;
 use Sulu\Bundle\FormBundle\Entity\Dynamic;
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;
@@ -113,12 +114,14 @@ class DynamicFormType extends AbstractType
                 $options['attr']['placeholder'] = $placeholder;
             }
 
+            $formFieldType = $this->typePool->get($field->getType());
+
             // required
-            if ($field->getRequired()) {
+            if (!$formFieldType instanceof FreeTextType && $field->getRequired()) {
                 $options['constraints'][] = new NotBlank();
             }
 
-            $this->typePool->get($field->getType())->build($builder, $field, $locale, $options);
+            $formFieldType->build($builder, $field, $locale, $options);
         }
 
         // Add hidden locale. (de, en, ...)

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\FormBundle\Form\Type;
 use Sulu\Bundle\FormBundle\Dynamic\Checksum;
 use Sulu\Bundle\FormBundle\Dynamic\FormFieldTypePool;
 use Sulu\Bundle\FormBundle\Dynamic\Types\FreeTextType;
+use Sulu\Bundle\FormBundle\Dynamic\Types\HeadlineType;
 use Sulu\Bundle\FormBundle\Entity\Dynamic;
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Exception\FormNotFoundException;

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -118,7 +118,11 @@ class DynamicFormType extends AbstractType
             $formFieldType = $this->typePool->get($field->getType());
 
             // required
-            if (!$formFieldType instanceof FreeTextType && $field->getRequired()) {
+            if (
+                !$formFieldType instanceof FreeTextType
+                && !$formFieldType instanceof HeadlineType
+                && $field->getRequired()
+            ) {
                 $options['constraints'][] = new NotBlank();
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #379
| Related issues/PRs | #379
| License | MIT

#### What's in this PR?

Checking field type before adding required constraint to avoid required constraint on free text fields.

EDIT: Maybe a easier way would be to reset all constraints for this type ?
![image](https://github.com/sulu/SuluFormBundle/assets/6411030/7f73d71c-4089-4382-b649-709d4ad20682)

