### PR TITLE
Add missing no update to ci install script

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -107,7 +107,7 @@ jobs:
                   coverage: none
 
             - name: Remove not required tooling for tests
-              run: composer remove php-cs-fixer/shim --dev
+              run: composer remove php-cs-fixer/shim "*phpstan*" --dev --no-update
 
             - name: Install composer dependencies
               uses: ramsey/composer-install@v1


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Add missing no update to ci install script

#### Why?

Install is the next step this way comoser is trigger two times.