### PR TITLE
Fix that invalid form returns http 422 status code

### DIFF
--- a/Event/RequestListener.php
+++ b/Event/RequestListener.php
@@ -17,7 +17,9 @@ use Sulu\Bundle\FormBundle\Form\BuilderInterface;
 use Sulu\Bundle\FormBundle\Form\HandlerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class RequestListener
 {
@@ -40,6 +42,14 @@ class RequestListener
      * @var EventDispatcherInterface
      */
     protected $eventDispatcher;
+
+    /**
+     * Flag set to true when an invalid form is submitted,
+     * so we can set the http return code to 422.
+     *
+     * @var bool
+     */
+    protected $invalidSubmittedForm = false;
 
     /**
      * RequestListener constructor.
@@ -73,8 +83,14 @@ class RequestListener
         try {
             $form = $this->formBuilder->buildByRequest($request);
 
-            if (!$form || !$form->isSubmitted() || !$form->isValid()) {
+            if (!$form || !$form->isSubmitted()) {
                 // do nothing when no form was found or not valid
+                return;
+            }
+
+            if ($form && $form->isSubmitted() && !$form->isValid()) {
+                $this->invalidSubmittedForm = true;
+
                 return;
             }
         } catch (\Exception $e) {
@@ -93,6 +109,21 @@ class RequestListener
             $this->eventDispatcher->dispatch($dynFormSavedEvent, DynFormSavedEvent::NAME);
 
             $response = new RedirectResponse('?send=true');
+            $event->setResponse($response);
+        }
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (\method_exists($event, 'isMainRequest') ? !$event->isMainRequest() : !$event->isMasterRequest()) {
+            // do nothing if it's not the master request
+            return;
+        }
+
+        if ($this->invalidSubmittedForm) {
+            $response = $event->getResponse() ?? new Response();
+            $response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
+
             $event->setResponse($response);
         }
     }

--- a/Event/RequestListener.php
+++ b/Event/RequestListener.php
@@ -20,8 +20,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Contracts\Service\ResetInterface;
 
-class RequestListener
+class RequestListener implements ResetInterface
 {
     /**
      * @var BuilderInterface
@@ -126,5 +127,10 @@ class RequestListener
 
             $event->setResponse($response);
         }
+    }
+
+    public function reset(): void
+    {
+        $this->invalidSubmittedForm = false;
     }
 }

--- a/Event/RequestListener.php
+++ b/Event/RequestListener.php
@@ -88,7 +88,7 @@ class RequestListener
                 return;
             }
 
-            if ($form && $form->isSubmitted() && !$form->isValid()) {
+            if (!$form->isValid()) {
                 $this->invalidSubmittedForm = true;
 
                 return;
@@ -121,7 +121,7 @@ class RequestListener
         }
 
         if ($this->invalidSubmittedForm) {
-            $response = $event->getResponse() ?? new Response();
+            $response = $event->getResponse();
             $response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
 
             $event->setResponse($response);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -104,6 +104,7 @@
             <argument type="service" id="event_dispatcher" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
+            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>
 
         <!-- List Builder -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -105,6 +105,7 @@
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
+            <tag name="kernel.reset" method="reset" />
         </service>
 
         <!-- List Builder -->

--- a/Tests/Functional/Mail/HelperTestCase.php
+++ b/Tests/Functional/Mail/HelperTestCase.php
@@ -73,12 +73,21 @@ class HelperTestCase extends SuluTestCase
         $this->assertEquals(1, $crawler->filter($formSelector)->count());
 
         $formElm = $crawler->filter($formSelector)->first()->form([
+            $formName . '[email]' => '',
+            $formName . '[email1]' => '',
+        ]);
+
+        $this->client->enableProfiler();
+        $crawler = $this->client->submit($formElm);
+        $this->assertResponseStatusCodeSame(422);
+
+        $formElm = $crawler->filter($formSelector)->first()->form([
             $formName . '[email]' => 'test@example.org',
             $formName . '[email1]' => 'jon@example.org',
         ]);
 
-        $this->client->enableProfiler();
         $this->client->submit($formElm);
+        $this->assertResponseStatusCodeSame(302);
         $this->assertResponseRedirects('?send=true');
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -806,6 +806,11 @@ parameters:
 			path: Event/RequestListener.php
 
 		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\ResponseEvent\\:\\:isMasterRequest\\(\\)\\.$#"
+			count: 1
+			path: Event/RequestListener.php
+
+		-
 			message: "#^In method \"Sulu\\\\Bundle\\\\FormBundle\\\\Event\\\\RequestListener\\:\\:onKernelRequest\", caught \"Exception\" must be rethrown\\. Either catch a more specific exception or add a \"throw\" clause in the \"catch\" block to propagate the exception\\. More info\\: http\\://bit\\.ly/failloud$#"
 			count: 1
 			path: Event/RequestListener.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #383
| License | MIT

#### What's in this PR?

Return the correct http code (422), when an invalid form is submitted.

#### Why?

Using Hotwire Turbo and this bundle, submit a form with invalid value is causing problems : no error displayed and no redirection.

#### To Do

- [x] Add tests (I prefer to wait your approval on the way I implemented that) ;
