### PR TITLE
Fix type deprecation for list properties

### DIFF
--- a/Resources/config/lists/forms.xml
+++ b/Resources/config/lists/forms.xml
@@ -59,20 +59,20 @@
         <property
                 name="changed"
                 translation="sulu_admin.changed"
-                visibility="yes"
-                type="datetime">
+                visibility="yes">
             <field-name>changed</field-name>
             <entity-name>Sulu\Bundle\FormBundle\Entity\FormTranslation</entity-name>
             <joins ref="translation"/>
+            <transformer type="datetime"/>
         </property>
         <property
                 name="created"
                 translation="sulu_admin.created"
-                visibility="no"
-                type="datetime">
+                visibility="no">
             <field-name>created</field-name>
             <entity-name>Sulu\Bundle\FormBundle\Entity\FormTranslation</entity-name>
             <joins ref="translation"/>
+            <transformer type="datetime"/>
         </property>
     </properties>
 </list>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Related issues/PRs | https://github.com/sulu/sulu/pull/7553
| License | MIT

#### What's in this PR?

Fix deprecation `Since sulu/sulu 2.2: Attribute "type" of list property should not be used anymore! Use "<transformer type="..."/>" inside of property instead.`
