### PR TITLE
Deprecate CSRF Token loading over render_esi as ESI not longer works to start a Session since Symfony 5.4, this was case in Varnish always

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -82,7 +82,7 @@ jobs:
                       database: mysql
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
-                      composer-options: '--ignore-platform-reqs'
+                      composer-stability: 'dev'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:root@127.0.0.1/sulu_form_test?serverVersion=5.7
@@ -123,6 +123,10 @@ jobs:
               # These tools are not required to run tests, so we are removing them to improve dependency resolving and
               # testing lowest versions.
               run: composer remove "*php-cs-fixer*" "*phpstan*" "*rector*" --dev --no-update
+
+            - name: Set composer stability
+              if: ${{ matrix.composer-stability }}
+              run: composer config minimum-stability ${{ matrix.composer-stability }}
 
             - name: Install composer dependencies
               uses: ramsey/composer-install@v2

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -52,6 +52,7 @@ jobs:
                       database: mysql
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
+                      composer-stability: 'dev'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:root@127.0.0.1/sulu_form_test?serverVersion=5.7

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -52,7 +52,6 @@ jobs:
                       database: mysql
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
-                      composer-stability: 'dev'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:root@127.0.0.1/sulu_form_test?serverVersion=5.7

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,6 +31,7 @@ $config->setRiskyAllowed(true)
         'phpdoc_types_order' => false,
         'single_line_throw' => false,
         'single_line_comment_spacing' => false,
+        'trailing_comma_in_multiline' => false,
     ])
     ->setFinder($finder);
 

--- a/Resources/doc/csrf.md
+++ b/Resources/doc/csrf.md
@@ -24,7 +24,7 @@ sulu_form.token:
         _requestAnalyzer: false
 ```
 
-### A. Ajax with jquery
+### A. Ajax without a JavaScript Framework
 
 A simple example for loading the csrf token over ajax looks like this:
 
@@ -67,7 +67,7 @@ When using [`@sulu/web`](https://github.com/sulu/web-js) / [`sulu/web-twig`](htt
 {%- block csrf_token_widget -%}
     {{ block('hidden_widget') }}
 
-    {% do register_component('csrf-token', { id: id, formName: form.parent.vars.name }) %}
+    {% do prepare_component('csrf-token', { id: id, formName: form.parent.vars.name }) %}
 {% endblock %}
 ```
 

--- a/Resources/doc/csrf.md
+++ b/Resources/doc/csrf.md
@@ -12,8 +12,6 @@ sulu_form:
 
 ## Ajax
 
-> This solution is required when pages are cached using `Varnish`:
-
 ```yaml
 # config/routes/sulu_form.yaml
 
@@ -96,21 +94,4 @@ import web from '@sulu/web';
 import CsrfToken from './components/csrf-token';
 
 web.registerComponent('csrf-token', CsrfToken);
-```
-
-## ESI
-
-> This solution does not work with Symfony 5.4 or later. Please use ajax loading when enabling csrf protection.
-
-Add the following to your form theme to overwrite the default
-behaviour of token generation or use the `@SuluForm/themes/basic.html.twig` theme.
-
-```twig
-{%- block csrf_token_widget -%}
-    {{ render_esi(controller('Sulu\\Bundle\\FormBundle\\Controller\\FormTokenController::tokenAction', {
-        'form': form.parent.vars.name,
-        'html': true,
-         _requestAnalyzer: false
-     })) }}
-{% endblock %}
 ```

--- a/Resources/doc/csrf.md
+++ b/Resources/doc/csrf.md
@@ -12,6 +12,8 @@ sulu_form:
 
 ## Ajax
 
+We need to add a new `Route` generates use the csrf token for the ajax based loading:
+
 ```yaml
 # config/routes/sulu_form.yaml
 

--- a/Resources/doc/static.md
+++ b/Resources/doc/static.md
@@ -232,14 +232,6 @@ https://github.com/symfony/symfony/blob/v2.7.0/src/Symfony/Bridge/Twig/Resources
 </html>
 ```
 
-ClientWebsiteBundle:forms:theme.html.twig:
-
-``` twig
-{% block token_widget %}
-    { render_esi(controller('Sulu\\Bundle\\FormBundle\\Controller\\FormTokenController::tokenAction', { 'form': 'form_type_alias', 'html': true })) }}
-{% endblock token_widget %}
-```
-
 ## E-Mail
 
 You need to create 2 emails(visitor/admin). Default Path are:  

--- a/Resources/views/themes/basic.html.twig
+++ b/Resources/views/themes/basic.html.twig
@@ -32,6 +32,7 @@
         If a request is not cacheable (eg. POST request), we can directly render it.
     #}
     {% if app.request.isMethodCacheable %}
+        {% deprecated 'CSRF Token over ESI is deprecated and fails since Symfony 5.4, use Ajax based CSRF Token loading, see CSRF docs.' %}
         {{ render_esi(controller) }}
     {% else %}
         {{ render(controller) }}

--- a/Tests/Functional/Mail/Fixtures/LoadFormFixture.php
+++ b/Tests/Functional/Mail/Fixtures/LoadFormFixture.php
@@ -22,7 +22,7 @@ use Sulu\Bundle\FormBundle\Entity\FormTranslationReceiver;
 
 class LoadFormFixture implements FixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $form = new Form();
         $form->setDefaultLocale('de');

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "twig/twig": "^1.41 || ^2.6 || ^3.0"
     },
     "require-dev": {
-        "doctrine/data-fixtures": "^1.3.3",
+        "doctrine/data-fixtures": "^1.3.3 || ^2.0",
         "doctrine/doctrine-bundle": "^1.10 || ^2.0",
         "drewm/mailchimp-api": "^2.2",
         "excelwebzone/recaptcha-bundle": "^1.4.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/validator": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/security-csrf": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/translation": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "twig/twig": "^1.41 || ^2.0 || ^3.0"
+        "twig/twig": "^1.41 || ^2.6 || ^3.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3.3",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,11 +41,6 @@ parameters:
 			path: Command/FormGeneratorCommand.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Command\\\\FormGeneratorCommand\\:\\:loadTestForm\\(\\) should return Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null but returns mixed\\.$#"
-			count: 1
-			path: Command/FormGeneratorCommand.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\FormConfiguration\\:\\:\\$adminMailConfiguration \\(Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfigurationInterface\\) does not accept Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfigurationInterface\\|null\\.$#"
 			count: 1
 			path: Configuration/FormConfiguration.php
@@ -1383,11 +1378,6 @@ parameters:
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Repository\\\\FormRepository\\:\\:getValue\\(\\) should return int\\|null but returns mixed\\.$#"
 			count: 2
-			path: Repository/FormRepository.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Repository\\\\FormRepository\\:\\:loadById\\(\\) should return Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null but returns mixed\\.$#"
-			count: 1
 			path: Repository/FormRepository.php
 
 		-


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Deprecate CSRF Token loading over render_esi 

#### Why?

As ESI not longer works to start a Session since Symfony 5.4, this was case in Varnish always.

#### Example Usage

See https://github.com/sulu/SuluFormBundle/blob/2.5.5/Resources/doc/csrf.md
