### PR TITLE
Fix issue with analyzedMediaUrl throws Exception

### DIFF
--- a/Event/ProtectedMediaSubscriber.php
+++ b/Event/ProtectedMediaSubscriber.php
@@ -95,8 +95,12 @@ class ProtectedMediaSubscriber implements EventSubscriberInterface
                 return;
             }
 
-            $mediaProperties = $this->formatCache->analyzedMediaUrl($request->getPathInfo());
-            $mediaId = $mediaProperties['id'];
+            try {
+                $mediaProperties = $this->formatCache->analyzedMediaUrl($request->getPathInfo());
+                $mediaId = $mediaProperties['id'];
+            } catch (\Exception $e) { // @phpstan-ignore-line // it is not the listeners responsibility to handle exceptions its later done by the controller
+                return;
+            }
         }
 
         if (!$mediaId) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Fix issue with analyzedMediaUrl throws Exception.

#### Why?

The analyzedMediaUrl can throw a exception but the listener is not responsible to handle this so we catch all and let the controller handle that exception correctly.
