### PR TITLE
Fix Symfony7 support for DateType

### DIFF
--- a/Dynamic/Types/DateType.php
+++ b/Dynamic/Types/DateType.php
@@ -41,6 +41,7 @@ class DateType implements FormFieldTypeInterface
         }
         $options['format'] = \IntlDateFormatter::LONG;
         $options['input'] = 'string';
+        $options['widget'] = 'choice';
         $builder->add($field->getKey(), $type, $options);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set DateType widget to choice.

#### Why?

Because otherwise "single_text" is used in Symfony 7 and then the wrong format is set and this error occurs:

```
Cannot use the "format" option of "Symfony\Component\Form\Extension\Core\Type\DateType" when the "html5" option is enabled.
```

From Symfony 6 to 7 the default was switched.
