### PR TITLE
Remove p tags from form field title

### DIFF
--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -83,6 +83,9 @@ class FormController extends AbstractRestController implements ClassResourceInte
         return FormAdmin::SECURITY_CONTEXT;
     }
 
+    /**
+     * @return class-string
+     */
     public function getModelClass(): string
     {
         return Form::class;

--- a/Form/Type/DynamicFormType.php
+++ b/Form/Type/DynamicFormType.php
@@ -95,6 +95,7 @@ class DynamicFormType extends AbstractType
             ];
 
             $title = $fieldTranslation->getTitle();
+            $title = \is_string($title) ? \str_replace(['<!--p-->', '<!--/p-->'], [''], $title) : $title;
             $placeholder = $fieldTranslation->getPlaceholder();
             $width = $field->getWidth() ?: 'full';
 

--- a/Resources/config/form-fields/default_field.xml
+++ b/Resources/config/form-fields/default_field.xml
@@ -9,6 +9,10 @@
         <meta>
             <title>sulu_form.title</title>
         </meta>
+
+        <params>
+            <param name="enter_mode" value="br"/>
+        </params>
     </property>
     <property name="shortTitle" type="text_line">
         <meta>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -256,6 +256,11 @@ parameters:
 			path: Controller/FormWebsiteController.php
 
 		-
+			message: "#^Parameter \\#1 \\$entityName of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilderFactoryInterface\\:\\:create\\(\\) expects class\\-string, string given\\.$#"
+			count: 1
+			path: Controller/ListController.php
+
+		-
 			message: "#^Parameter \\#1 \\$template of method Sulu\\\\Bundle\\\\FormBundle\\\\Provider\\\\ListProviderRegistry\\:\\:getEntityName\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: Controller/ListController.php
@@ -266,7 +271,7 @@ parameters:
 			path: Controller/ListController.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\ListBuilderInterface\\:\\:where\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$value of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\AbstractListBuilder\\:\\:where\\(\\) expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 3
 			path: Controller/ListController.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | [#issuenum](https://github.com/sulu/sulu/pull/8279)
| License | MIT

#### What's in this PR?

Remove p tags from form field title to avoid save issues.


Leave overlay opens on first save, when a form field with title is existing
<img width="1181" height="630" alt="image" src="https://github.com/user-attachments/assets/f5688e98-fd94-42d0-8812-c0b9f3a333c4" />
