### PR TITLE
Rename StructureTitleProvider to DimensionContentTitleProvider

### DIFF
--- a/Resources/config/title-providers.xml
+++ b/Resources/config/title-providers.xml
@@ -10,7 +10,7 @@
         </service>
 
         <!-- Page Title Provider -->
-        <service id="sulu_form.title_provider.page" class="Sulu\Bundle\FormBundle\TitleProvider\StructureTitleProvider">
+        <service id="sulu_form.title_provider.page" class="Sulu\Bundle\FormBundle\TitleProvider\DimensionContentTitleProvider">
             <argument type="service" id="request_stack"/>
 
             <tag name="sulu_form.title_provider" alias="page"/>

--- a/TitleProvider/DimensionContentTitleProvider.php
+++ b/TitleProvider/DimensionContentTitleProvider.php
@@ -17,8 +17,10 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides the title from the current page/article content.
+ *
+ * @internal
  */
-class StructureTitleProvider implements TitleProviderInterface
+final class DimensionContentTitleProvider implements TitleProviderInterface
 {
     public function __construct(
         private RequestStack $requestStack,

--- a/TitleProvider/TitleProviderInterface.php
+++ b/TitleProvider/TitleProviderInterface.php
@@ -11,9 +11,6 @@
 
 namespace Sulu\Bundle\FormBundle\TitleProvider;
 
-/**
- * Defines the form type implementation.
- */
 interface TitleProviderInterface
 {
     /**

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -68,12 +68,14 @@ The `PropertiesXmlLoader` and `DynamicFormMetadataLoader` have been refactored t
 
 The `StructureTitleProvider` has been refactored to use Sulu 3.0's new content architecture:
 
+- Uses a new name `DimensionContentTitleProvider`
 - Uses `DimensionContentInterface` instead of removed `StructureInterface`
 - Gets `object` from request attributes instead of `structure`
 - Uses `getResource()->getId()` instead of `getUuid()`
 - Gets title from `getTemplateData()['title']`
 
-If you extended this class, update your code accordingly.
+If you extended this class, update your code accordingly. This class is now final, to override it decorate the 
+`sulu_form.title_provider.page` service.
 
 ### Deprecated Symfony methods removed
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?
- Renaming the StructureTitleProvider (structures are a Sulu < 3.0 concept)
- Marking it internal
- Marking it final

#### Why?
Clearer naming an a better extension strategy.