### PR TITLE
Add shadow locale fallback for form resource loader and twig extension

### DIFF
--- a/Infrastructure/Sulu/Content/ResourceLoader/FormResourceLoader.php
+++ b/Infrastructure/Sulu/Content/ResourceLoader/FormResourceLoader.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\FormBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
+use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Repository\FormRepository;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 
@@ -23,17 +24,53 @@ class FormResourceLoader implements ResourceLoaderInterface
     ) {
     }
 
+    /**
+     * @param array<int|string> $ids
+     *
+     * @return array<int, Form>
+     */
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        $intIds = \array_map(static fn ($id) => (int) $id, $ids);
-        $result = $this->formRepository->loadByIds($intIds, $locale);
-
-        $mappedResult = [];
-        foreach ($result as $form) {
-            $mappedResult[$form->getId()] = $form;
+        if (null === $locale) {
+            return [];
         }
 
-        return $mappedResult;
+        $intIds = \array_map(static fn ($id) => (int) $id, $ids);
+        $mapped = $this->loadForLocale($intIds, $locale);
+
+        $missingIds = \array_values(\array_diff($intIds, \array_keys($mapped)));
+        $shadowLocale = $params['_shadowLocale'] ?? null;
+        if ([] !== $missingIds && \is_string($shadowLocale)) {
+            $mapped += $this->loadForLocale($missingIds, $shadowLocale);
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param int[] $ids
+     *
+     * @return array<int, Form>
+     */
+    private function loadForLocale(array $ids, string $locale): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        $mapped = [];
+        foreach ($this->formRepository->loadByIds($ids, $locale) as $form) {
+            // loadByIds ignores the locale filter, so check the translation explicitly.
+            if (null === $form->getTranslation($locale)) {
+                continue;
+            }
+
+            $id = $form->getId();
+            \assert(null !== $id);
+            $mapped[$id] = $form;
+        }
+
+        return $mapped;
     }
 
     public static function getKey(): string

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -159,6 +159,7 @@
         <service id="sulu_form.twig_extension" class="Sulu\Bundle\FormBundle\Twig\FormTwigExtension">
             <tag name="twig.extension"/>
             <argument type="service" id="sulu_form.builder"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
         </service>
 
         <!-- Checksum -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -159,7 +159,7 @@
         <service id="sulu_form.twig_extension" class="Sulu\Bundle\FormBundle\Twig\FormTwigExtension">
             <tag name="twig.extension"/>
             <argument type="service" id="sulu_form.builder"/>
-            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="request_stack"/>
         </service>
 
         <!-- Checksum -->

--- a/Tests/Functional/Infrastructure/Sulu/Content/ResourceLoader/FormResourceLoaderTest.php
+++ b/Tests/Functional/Infrastructure/Sulu/Content/ResourceLoader/FormResourceLoaderTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Tests\Functional\Infrastructure\Sulu\Content\ResourceLoader;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\FormBundle\Entity\Form;
+use Sulu\Bundle\FormBundle\Entity\FormTranslation;
+use Sulu\Bundle\FormBundle\Infrastructure\Sulu\Content\ResourceLoader\FormResourceLoader;
+use Sulu\Bundle\FormBundle\Repository\FormRepository;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class FormResourceLoaderTest extends SuluTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    private FormResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        static::purgeDatabase();
+        static::bootKernel();
+
+        $container = static::getContainer();
+        /** @var FormRepository $repository */
+        $repository = $container->get('sulu_form.repository.form');
+        $this->loader = new FormResourceLoader($repository);
+        $this->entityManager = static::getEntityManager();
+    }
+
+    public function testLoadReturnsEmptyWhenLocaleIsNull(): void
+    {
+        $form = $this->createForm(['en']);
+        $this->entityManager->flush();
+
+        $result = $this->loader->load([(string) $form->getId()], null);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testLoadReturnsFormsForRequestedLocale(): void
+    {
+        $formEn = $this->createForm(['en']);
+        $formDe = $this->createForm(['de']);
+        $formBoth = $this->createForm(['en', 'de']);
+        $this->entityManager->flush();
+
+        $ids = [$formEn->getId(), $formDe->getId(), $formBoth->getId()];
+
+        $result = $this->loader->load($ids, 'en');
+
+        $this->assertArrayHasKey($formEn->getId(), $result);
+        $this->assertArrayNotHasKey($formDe->getId(), $result);
+        $this->assertArrayHasKey($formBoth->getId(), $result);
+    }
+
+    public function testLoadFallsBackToShadowLocaleForMissingTranslations(): void
+    {
+        $formEn = $this->createForm(['en']);
+        $formDeOnly = $this->createForm(['de']);
+        $this->entityManager->flush();
+
+        $result = $this->loader->load(
+            [$formEn->getId(), $formDeOnly->getId()],
+            'en',
+            ['_shadowLocale' => 'de']
+        );
+
+        $this->assertArrayHasKey($formEn->getId(), $result);
+        $this->assertArrayHasKey($formDeOnly->getId(), $result);
+        $this->assertSame('title-en', $result[$formEn->getId()]->getTranslation('en')?->getTitle());
+        $this->assertSame('title-de', $result[$formDeOnly->getId()]->getTranslation('de')?->getTitle());
+    }
+
+    public function testLoadDoesNotFallBackWhenShadowLocaleAlsoMissing(): void
+    {
+        $formFr = $this->createForm(['fr']);
+        $this->entityManager->flush();
+
+        $result = $this->loader->load(
+            [$formFr->getId()],
+            'en',
+            ['_shadowLocale' => 'de']
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testLoadDoesNotFallBackWhenShadowLocaleNotProvided(): void
+    {
+        $formDeOnly = $this->createForm(['de']);
+        $this->entityManager->flush();
+
+        $result = $this->loader->load([$formDeOnly->getId()], 'en');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testLoadDoesNotFallBackWhenShadowLocaleIsNotString(): void
+    {
+        $formDeOnly = $this->createForm(['de']);
+        $this->entityManager->flush();
+
+        $result = $this->loader->load(
+            [$formDeOnly->getId()],
+            'en',
+            ['_shadowLocale' => null]
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testShadowDoesNotOverrideExistingPrimaryLocaleEntries(): void
+    {
+        $form = $this->createForm(['en', 'de']);
+        $this->entityManager->flush();
+
+        $result = $this->loader->load(
+            [$form->getId()],
+            'en',
+            ['_shadowLocale' => 'de']
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertArrayHasKey($form->getId(), $result);
+        $this->assertSame('title-en', $result[$form->getId()]->getTranslation('en')?->getTitle());
+    }
+
+    public function testLoadCastsStringIdsToInt(): void
+    {
+        $form = $this->createForm(['en']);
+        $this->entityManager->flush();
+
+        $result = $this->loader->load([(string) $form->getId()], 'en');
+
+        $this->assertArrayHasKey($form->getId(), $result);
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('form', FormResourceLoader::getKey());
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    private function createForm(array $locales): Form
+    {
+        $form = new Form();
+        $form->setDefaultLocale($locales[0]);
+
+        foreach ($locales as $locale) {
+            $translation = new FormTranslation();
+            $translation->setForm($form);
+            $translation->setLocale($locale);
+            $translation->setTitle('title-' . $locale);
+            $form->addTranslation($translation);
+        }
+
+        $this->entityManager->persist($form);
+
+        return $form;
+    }
+}

--- a/Tests/Unit/Twig/FormTwigExtensionTest.php
+++ b/Tests/Unit/Twig/FormTwigExtensionTest.php
@@ -21,10 +21,11 @@ use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Entity\FormTranslation;
 use Sulu\Bundle\FormBundle\Form\BuilderInterface;
 use Sulu\Bundle\FormBundle\Twig\FormTwigExtension;
-use Sulu\Component\Localization\Localization;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Content\Domain\Model\ShadowInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class FormTwigExtensionTest extends TestCase
 {
@@ -35,21 +36,18 @@ class FormTwigExtensionTest extends TestCase
      */
     private $formBuilder;
 
-    /**
-     * @var RequestAnalyzerInterface|ObjectProphecy
-     */
-    private $requestAnalyzer;
+    private RequestStack $requestStack;
 
     private FormTwigExtension $extension;
 
     protected function setUp(): void
     {
         $this->formBuilder = $this->prophesize(BuilderInterface::class);
-        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->requestStack = new RequestStack();
 
         $this->extension = new FormTwigExtension(
             $this->formBuilder->reveal(),
-            $this->requestAnalyzer->reveal()
+            $this->requestStack
         );
     }
 
@@ -119,20 +117,22 @@ class FormTwigExtensionTest extends TestCase
             ->shouldBeCalledOnce()
             ->willReturn($formInterface->reveal());
 
-        $this->requestAnalyzer->getCurrentLocalization()->shouldNotBeCalled();
-
         $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'de');
 
         $this->assertSame($view, $result);
     }
 
-    public function testGetFormByContentFallsBackToRequestLocaleWhenTranslationExists(): void
+    public function testGetFormByContentUsesShadowLocaleWhenAvailable(): void
     {
         $form = $this->createForm(5, ['en', 'de'], 'en');
 
-        $this->requestAnalyzer->getCurrentLocalization()
-            ->shouldBeCalledOnce()
-            ->willReturn(new Localization('de'));
+        $shadowContent = $this->prophesize(ShadowInterface::class);
+        $shadowContent->getShadowLocale()->willReturn('de');
+
+        $request = new Request();
+        $request->setLocale('en');
+        $request->attributes->set('object', $shadowContent->reveal());
+        $this->requestStack->push($request);
 
         $view = new FormView();
         $formInterface = $this->prophesize(FormInterface::class);
@@ -147,13 +147,38 @@ class FormTwigExtensionTest extends TestCase
         $this->assertSame($view, $result);
     }
 
-    public function testGetFormByContentFallsBackToDefaultLocaleWhenRequestLocaleHasNoTranslation(): void
+    public function testGetFormByContentFallsBackToRequestLocaleWhenObjectIsNotShadow(): void
+    {
+        $form = $this->createForm(5, ['en', 'de'], 'en');
+
+        $request = new Request();
+        $request->setLocale('de');
+        $this->requestStack->push($request);
+
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl');
+
+        $this->assertSame($view, $result);
+    }
+
+    public function testGetFormByContentFallsBackToRequestLocaleWhenShadowLocaleIsNull(): void
     {
         $form = $this->createForm(5, ['en'], 'en');
 
-        $this->requestAnalyzer->getCurrentLocalization()
-            ->shouldBeCalledOnce()
-            ->willReturn(new Localization('de'));
+        $shadowContent = $this->prophesize(ShadowInterface::class);
+        $shadowContent->getShadowLocale()->willReturn(null);
+
+        $request = new Request();
+        $request->setLocale('en');
+        $request->attributes->set('object', $shadowContent->reveal());
+        $this->requestStack->push($request);
 
         $view = new FormView();
         $formInterface = $this->prophesize(FormInterface::class);
@@ -168,19 +193,15 @@ class FormTwigExtensionTest extends TestCase
         $this->assertSame($view, $result);
     }
 
-    public function testGetFormByContentFallsBackToDefaultLocaleWhenNoCurrentLocalization(): void
+    public function testGetFormByContentPassesNullLocaleWhenNoRequest(): void
     {
         $form = $this->createForm(5, ['en'], 'en');
-
-        $this->requestAnalyzer->getCurrentLocalization()
-            ->shouldBeCalledOnce()
-            ->willReturn(null);
 
         $view = new FormView();
         $formInterface = $this->prophesize(FormInterface::class);
         $formInterface->createView()->willReturn($view);
 
-        $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
+        $this->formBuilder->build(5, 'page', 'tpl', null, 'form')
             ->shouldBeCalledOnce()
             ->willReturn($formInterface->reveal());
 

--- a/Tests/Unit/Twig/FormTwigExtensionTest.php
+++ b/Tests/Unit/Twig/FormTwigExtensionTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\FormBundle\Entity\Form;
+use Sulu\Bundle\FormBundle\Entity\FormTranslation;
+use Sulu\Bundle\FormBundle\Form\BuilderInterface;
+use Sulu\Bundle\FormBundle\Twig\FormTwigExtension;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+class FormTwigExtensionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var BuilderInterface|ObjectProphecy
+     */
+    private $formBuilder;
+
+    /**
+     * @var RequestAnalyzerInterface|ObjectProphecy
+     */
+    private $requestAnalyzer;
+
+    private FormTwigExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->formBuilder = $this->prophesize(BuilderInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->extension = new FormTwigExtension(
+            $this->formBuilder->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    public function testGetFunctionsExposesExpectedFunctions(): void
+    {
+        $names = \array_map(static fn ($function) => $function->getName(), $this->extension->getFunctions());
+
+        $this->assertContains('sulu_form_get_by_id', $names);
+        $this->assertContains('sulu_form_build', $names);
+    }
+
+    public function testGetFormByIdReturnsNullWhenBuilderReturnsNull(): void
+    {
+        $this->formBuilder->build(7, 'page', 'tpl', 'en', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn(null);
+
+        $this->assertNull($this->extension->getFormById(7, 'page', 'tpl', 'en'));
+    }
+
+    public function testGetFormByIdReturnsView(): void
+    {
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
+
+        $this->formBuilder->build(7, 'page', 'tpl', 'en', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $this->assertSame($view, $this->extension->getFormById(7, 'page', 'tpl', 'en'));
+    }
+
+    public function testGetFormByContentReturnsNullWhenEntityMissing(): void
+    {
+        $this->formBuilder->build(Argument::cetera())->shouldNotBeCalled();
+
+        $this->assertNull($this->extension->getFormByContent([], 'page', 'tpl'));
+    }
+
+    public function testGetFormByContentReturnsNullWhenEntityIsNotForm(): void
+    {
+        $this->formBuilder->build(Argument::cetera())->shouldNotBeCalled();
+
+        $this->assertNull($this->extension->getFormByContent(['entity' => new \stdClass()], 'page', 'tpl'));
+    }
+
+    public function testGetFormByContentReturnsNullWhenFormHasNoId(): void
+    {
+        $form = new Form();
+        $form->setDefaultLocale('en');
+
+        $this->formBuilder->build(Argument::cetera())->shouldNotBeCalled();
+
+        $this->assertNull($this->extension->getFormByContent(['entity' => $form], 'page', 'tpl'));
+    }
+
+    public function testGetFormByContentUsesExplicitLocale(): void
+    {
+        $form = $this->createForm(5, ['en', 'de'], 'en');
+
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $this->requestAnalyzer->getCurrentLocalization()->shouldNotBeCalled();
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'de');
+
+        $this->assertSame($view, $result);
+    }
+
+    public function testGetFormByContentFallsBackToRequestLocaleWhenTranslationExists(): void
+    {
+        $form = $this->createForm(5, ['en', 'de'], 'en');
+
+        $this->requestAnalyzer->getCurrentLocalization()
+            ->shouldBeCalledOnce()
+            ->willReturn(new Localization('de'));
+
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl');
+
+        $this->assertSame($view, $result);
+    }
+
+    public function testGetFormByContentFallsBackToDefaultLocaleWhenRequestLocaleHasNoTranslation(): void
+    {
+        $form = $this->createForm(5, ['en'], 'en');
+
+        $this->requestAnalyzer->getCurrentLocalization()
+            ->shouldBeCalledOnce()
+            ->willReturn(new Localization('de'));
+
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl');
+
+        $this->assertSame($view, $result);
+    }
+
+    public function testGetFormByContentFallsBackToDefaultLocaleWhenNoCurrentLocalization(): void
+    {
+        $form = $this->createForm(5, ['en'], 'en');
+
+        $this->requestAnalyzer->getCurrentLocalization()
+            ->shouldBeCalledOnce()
+            ->willReturn(null);
+
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl');
+
+        $this->assertSame($view, $result);
+    }
+
+    public function testGetFormByContentReturnsNullWhenBuilderReturnsNull(): void
+    {
+        $form = $this->createForm(5, ['en'], 'en');
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn(null);
+
+        $this->assertNull($this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'en'));
+    }
+
+    /**
+     * @param string[] $translationLocales
+     */
+    private function createForm(int $id, array $translationLocales, string $defaultLocale): Form
+    {
+        $form = new Form();
+        $form->setDefaultLocale($defaultLocale);
+
+        foreach ($translationLocales as $locale) {
+            $translation = new FormTranslation();
+            $translation->setLocale($locale);
+            $translation->setTitle('title-' . $locale);
+            $translation->setForm($form);
+            $form->addTranslation($translation);
+        }
+
+        (new \ReflectionProperty(Form::class, 'id'))->setValue($form, $id);
+
+        return $form;
+    }
+}

--- a/Twig/FormTwigExtension.php
+++ b/Twig/FormTwigExtension.php
@@ -13,23 +13,17 @@ namespace Sulu\Bundle\FormBundle\Twig;
 
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Form\BuilderInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\Form\FormView;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-/**
- * Extension for content form generation.
- */
 class FormTwigExtension extends AbstractExtension
 {
-    /**
-     * @var BuilderInterface
-     */
-    private $formBuilder;
-
-    public function __construct(BuilderInterface $formBuilder)
-    {
-        $this->formBuilder = $formBuilder;
+    public function __construct(
+        private BuilderInterface $formBuilder,
+        private RequestAnalyzerInterface $requestAnalyzer,
+    ) {
     }
 
     public function getFunctions(): array
@@ -64,6 +58,13 @@ class FormTwigExtension extends AbstractExtension
         $formId = $form->getId();
         if (null === $formId) {
             return null;
+        }
+
+        if (null === $locale) {
+            $requestLocale = $this->requestAnalyzer->getCurrentLocalization()?->getLocale();
+            $locale = (null !== $requestLocale && null !== $form->getTranslation($requestLocale))
+                ? $requestLocale
+                : $form->getDefaultLocale();
         }
 
         $builtForm = $this->formBuilder->build(

--- a/Twig/FormTwigExtension.php
+++ b/Twig/FormTwigExtension.php
@@ -13,8 +13,9 @@ namespace Sulu\Bundle\FormBundle\Twig;
 
 use Sulu\Bundle\FormBundle\Entity\Form;
 use Sulu\Bundle\FormBundle\Form\BuilderInterface;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Content\Domain\Model\ShadowInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -22,7 +23,7 @@ class FormTwigExtension extends AbstractExtension
 {
     public function __construct(
         private BuilderInterface $formBuilder,
-        private RequestAnalyzerInterface $requestAnalyzer,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -61,10 +62,10 @@ class FormTwigExtension extends AbstractExtension
         }
 
         if (null === $locale) {
-            $requestLocale = $this->requestAnalyzer->getCurrentLocalization()?->getLocale();
-            $locale = (null !== $requestLocale && null !== $form->getTranslation($requestLocale))
-                ? $requestLocale
-                : $form->getDefaultLocale();
+            $request = $this->requestStack->getCurrentRequest();
+            $object = $request?->attributes->get('object');
+            $shadowLocale = $object instanceof ShadowInterface ? $object->getShadowLocale() : null;
+            $locale = $shadowLocale ?? $request?->getLocale();
         }
 
         $builtForm = $this->formBuilder->build(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The `FormResourceLoader` now falls back to the shadow locale passed via the `_shadowLocale` parameter when a form has no translation for the requested locale. It also filters loaded forms by the actual translation, since `loadByIds` does not respect the locale on its own. The `FormTwigExtension` receives the request analyzer and resolves a missing locale either from the current localization or from the form's default locale.

#### Why?

Forms rendered on shadow pages stayed empty because the loader returned no result when the form had no translation in the shadow's target locale. Templates that called the form twig function without a locale could also end up with `null`, which broke the rendered form. The fallback chain restores the expected output for shadow locales and locale-less twig calls.