### PR TITLE
Fix locale resolving priority for form shadow locale fallback

### DIFF
--- a/Tests/Unit/Twig/FormTwigExtensionTest.php
+++ b/Tests/Unit/Twig/FormTwigExtensionTest.php
@@ -105,7 +105,7 @@ class FormTwigExtensionTest extends TestCase
         $this->assertNull($this->extension->getFormByContent(['entity' => $form], 'page', 'tpl'));
     }
 
-    public function testGetFormByContentUsesExplicitLocale(): void
+    public function testGetFormByContentBuildsWithExplicitLocale(): void
     {
         $form = $this->createForm(5, ['en', 'de'], 'en');
 
@@ -122,78 +122,7 @@ class FormTwigExtensionTest extends TestCase
         $this->assertSame($view, $result);
     }
 
-    public function testGetFormByContentUsesShadowLocaleWhenAvailable(): void
-    {
-        $form = $this->createForm(5, ['en', 'de'], 'en');
-
-        $shadowContent = $this->prophesize(ShadowInterface::class);
-        $shadowContent->getShadowLocale()->willReturn('de');
-
-        $request = new Request();
-        $request->setLocale('en');
-        $request->attributes->set('object', $shadowContent->reveal());
-        $this->requestStack->push($request);
-
-        $view = new FormView();
-        $formInterface = $this->prophesize(FormInterface::class);
-        $formInterface->createView()->willReturn($view);
-
-        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
-            ->shouldBeCalledOnce()
-            ->willReturn($formInterface->reveal());
-
-        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl');
-
-        $this->assertSame($view, $result);
-    }
-
-    public function testGetFormByContentFallsBackToRequestLocaleWhenObjectIsNotShadow(): void
-    {
-        $form = $this->createForm(5, ['en', 'de'], 'en');
-
-        $request = new Request();
-        $request->setLocale('de');
-        $this->requestStack->push($request);
-
-        $view = new FormView();
-        $formInterface = $this->prophesize(FormInterface::class);
-        $formInterface->createView()->willReturn($view);
-
-        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
-            ->shouldBeCalledOnce()
-            ->willReturn($formInterface->reveal());
-
-        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl');
-
-        $this->assertSame($view, $result);
-    }
-
-    public function testGetFormByContentFallsBackToRequestLocaleWhenShadowLocaleIsNull(): void
-    {
-        $form = $this->createForm(5, ['en'], 'en');
-
-        $shadowContent = $this->prophesize(ShadowInterface::class);
-        $shadowContent->getShadowLocale()->willReturn(null);
-
-        $request = new Request();
-        $request->setLocale('en');
-        $request->attributes->set('object', $shadowContent->reveal());
-        $this->requestStack->push($request);
-
-        $view = new FormView();
-        $formInterface = $this->prophesize(FormInterface::class);
-        $formInterface->createView()->willReturn($view);
-
-        $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
-            ->shouldBeCalledOnce()
-            ->willReturn($formInterface->reveal());
-
-        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl');
-
-        $this->assertSame($view, $result);
-    }
-
-    public function testGetFormByContentPassesNullLocaleWhenNoRequest(): void
+    public function testGetFormByContentBuildsWithNullLocaleWhenNoRequest(): void
     {
         $form = $this->createForm(5, ['en'], 'en');
 
@@ -210,15 +139,119 @@ class FormTwigExtensionTest extends TestCase
         $this->assertSame($view, $result);
     }
 
-    public function testGetFormByContentReturnsNullWhenBuilderReturnsNull(): void
+    public function testGetFormByContentDoesNotFallBackWhenBuildSucceeds(): void
     {
-        $form = $this->createForm(5, ['en'], 'en');
+        $form = $this->createForm(5, ['en', 'de'], 'en');
+
+        $shadowContent = $this->prophesize(ShadowInterface::class);
+        $shadowContent->getShadowLocale()->willReturn('de');
+
+        $request = new Request();
+        $request->attributes->set('object', $shadowContent->reveal());
+        $this->requestStack->push($request);
+
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
+            ->shouldNotBeCalled();
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'en');
+
+        $this->assertSame($view, $result);
+    }
+
+    public function testGetFormByContentFallsBackToShadowLocaleWhenBuildReturnsNull(): void
+    {
+        $form = $this->createForm(5, ['de'], 'de');
+
+        $shadowContent = $this->prophesize(ShadowInterface::class);
+        $shadowContent->getShadowLocale()->willReturn('de');
+
+        $request = new Request();
+        $request->attributes->set('object', $shadowContent->reveal());
+        $this->requestStack->push($request);
+
+        $view = new FormView();
+        $formInterface = $this->prophesize(FormInterface::class);
+        $formInterface->createView()->willReturn($view);
 
         $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
             ->shouldBeCalledOnce()
             ->willReturn(null);
 
-        $this->assertNull($this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'en'));
+        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn($formInterface->reveal());
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'en');
+
+        $this->assertSame($view, $result);
+    }
+
+    public function testGetFormByContentReturnsNullWhenNoShadowFallbackAvailable(): void
+    {
+        $form = $this->createForm(5, ['en'], 'en');
+
+        $request = new Request();
+        $this->requestStack->push($request);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'fr', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn(null);
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'fr');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetFormByContentDoesNotFallBackWhenShadowLocaleIsNull(): void
+    {
+        $form = $this->createForm(5, ['en'], 'en');
+
+        $shadowContent = $this->prophesize(ShadowInterface::class);
+        $shadowContent->getShadowLocale()->willReturn(null);
+
+        $request = new Request();
+        $request->attributes->set('object', $shadowContent->reveal());
+        $this->requestStack->push($request);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'fr', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn(null);
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'fr');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetFormByContentReturnsNullWhenShadowFallbackAlsoFails(): void
+    {
+        $form = $this->createForm(5, [], 'en');
+
+        $shadowContent = $this->prophesize(ShadowInterface::class);
+        $shadowContent->getShadowLocale()->willReturn('de');
+
+        $request = new Request();
+        $request->attributes->set('object', $shadowContent->reveal());
+        $this->requestStack->push($request);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'en', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn(null);
+
+        $this->formBuilder->build(5, 'page', 'tpl', 'de', 'form')
+            ->shouldBeCalledOnce()
+            ->willReturn(null);
+
+        $result = $this->extension->getFormByContent(['entity' => $form], 'page', 'tpl', 'en');
+
+        $this->assertNull($result);
     }
 
     /**

--- a/Twig/FormTwigExtension.php
+++ b/Twig/FormTwigExtension.php
@@ -61,12 +61,9 @@ class FormTwigExtension extends AbstractExtension
             return null;
         }
 
-        if (null === $locale) {
-            $request = $this->requestStack->getCurrentRequest();
-            $object = $request?->attributes->get('object');
-            $shadowLocale = $object instanceof ShadowInterface ? $object->getShadowLocale() : null;
-            $locale = $shadowLocale ?? $request?->getLocale();
-        }
+        $request = $this->requestStack->getCurrentRequest();
+        $object = $request?->attributes->get('object');
+        $shadowLocale = $object instanceof ShadowInterface ? $object->getShadowLocale() : null;
 
         $builtForm = $this->formBuilder->build(
             $formId,
@@ -75,6 +72,16 @@ class FormTwigExtension extends AbstractExtension
             $locale,
             $name
         );
+
+        if (null === $builtForm && null !== $shadowLocale) {
+            $builtForm = $this->formBuilder->build(
+                $formId,
+                $type,
+                $typeId,
+                $shadowLocale,
+                $name
+            );
+        }
 
         return $builtForm?->createView();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #431
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Forward-ports the shadow locale fallback for the form resource loader and twig extension to the 3.0 branch and corrects the locale resolving priority. The requested locale now always wins when a translation exists, and the shadow locale is used only as a true fallback.

#### Why?

Followup to https://github.com/sulu/SuluFormBundle/pull/431. The original change could resolve forms to the shadow locale even when the requested locale had a translation, because `loadByIds` ignores the locale filter and the fallback was merged unconditionally.