### PR TITLE
Add alphabetical sorting to form field block types

### DIFF
--- a/Metadata/DynamicFormMetadataLoader.php
+++ b/Metadata/DynamicFormMetadataLoader.php
@@ -111,8 +111,8 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
     }
 
     /**
-     * Orders the block field types by their translated title so the admin user sees them
-     * alphabetically in their own interface locale.
+     * Sorts the block field types alphabetically by their translated title, using the requested
+     * locale or the first configured locale when the requested one is not configured.
      */
     private function sortFieldTypesByLocale(FormMetadata $form, string $locale): void
     {

--- a/Metadata/DynamicFormMetadataLoader.php
+++ b/Metadata/DynamicFormMetadataLoader.php
@@ -70,17 +70,9 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
         }
         Assert::notEmpty($fieldTypeMetaDataCollection, 'No field type metadata loaded');
 
-        $sortLocale = (string) \reset($this->locales);
-        \usort(
-            $fieldTypeMetaDataCollection,
-            static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($sortLocale), $b->getTitle($sortLocale))
-        );
-
         foreach ($fieldTypeMetaDataCollection as $fieldTypeMetaData) {
             $fields->addType($fieldTypeMetaData);
         }
-
-        $fields->setDefaultType(\current($fields->getTypes())->getName());
         $section->addItem($fields);
 
         $formItems = $formMetadata->getItems();
@@ -111,7 +103,46 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
 
         $form = \unserialize(\file_get_contents($configCache->getPath()));
 
+        if ($form instanceof FormMetadata) {
+            $this->sortFieldTypesByLocale($form, $locale);
+        }
+
         return $form;
+    }
+
+    /**
+     * Orders the block field types by their translated title so the admin user sees them
+     * alphabetically in their own interface locale.
+     */
+    private function sortFieldTypesByLocale(FormMetadata $form, string $locale): void
+    {
+        $section = $form->getItems()['formFields'] ?? null;
+        if (!$section instanceof SectionMetadata) {
+            return;
+        }
+
+        $fields = $section->getItems()['fields'] ?? null;
+        if (!$fields instanceof FieldMetadata) {
+            return;
+        }
+
+        $sortLocale = \in_array($locale, $this->locales, true) ? $locale : (string) \reset($this->locales);
+
+        $types = $fields->getTypes();
+        \uasort(
+            $types,
+            static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($sortLocale), $b->getTitle($sortLocale))
+        );
+
+        foreach (\array_keys($fields->getTypes()) as $typeKey) {
+            $fields->removeType($typeKey);
+        }
+
+        foreach ($types as $type) {
+            $fields->addType($type);
+        }
+
+        $fields->setDefaultType((string) \array_key_first($types));
     }
 
     private function loadFieldTypeMetadata(string $typeKey, FormFieldTypeInterface $type): FormMetadata

--- a/Metadata/DynamicFormMetadataLoader.php
+++ b/Metadata/DynamicFormMetadataLoader.php
@@ -70,6 +70,12 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
         }
         Assert::notEmpty($fieldTypeMetaDataCollection, 'No field type metadata loaded');
 
+        $sortLocale = (string) \reset($this->locales);
+        \usort(
+            $fieldTypeMetaDataCollection,
+            static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($sortLocale), $b->getTitle($sortLocale))
+        );
+
         foreach ($fieldTypeMetaDataCollection as $fieldTypeMetaData) {
             $fields->addType($fieldTypeMetaData);
         }

--- a/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
+++ b/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
@@ -145,8 +145,6 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
 
     public function testGetMetadataFieldTypesAreSortedByRequestedLocale(): void
     {
-        $orderByLocale = [];
-
         foreach (['de', 'en'] as $locale) {
             $formMetadata = $this->dynamicFormMetadataLoader->getMetadata('form_details', $locale);
             $this->assertInstanceOf(FormMetadata::class, $formMetadata);
@@ -170,15 +168,7 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
 
             $this->assertSame(\array_key_first($types), $fields->getDefaultType());
             $this->assertSame('attachment', \array_key_first($types));
-
-            $orderByLocale[$locale] = \array_keys($types);
         }
-
-        $this->assertNotSame(
-            $orderByLocale['de'],
-            $orderByLocale['en'],
-            'German and English block type orders must differ because they are sorted by their translated title.'
-        );
     }
 
     public function testGetMetadataLabelsEnglish(): void

--- a/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
+++ b/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
@@ -145,6 +145,9 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
 
     public function testGetMetadataFieldTypesAreSortedByTitle(): void
     {
+        $enabledLocales = $this->getContainer()->getParameter('kernel.enabled_locales');
+        $sortLocale = (string) (\reset($enabledLocales) ?: 'de');
+
         foreach (['de', 'en'] as $locale) {
             $formMetadata = $this->dynamicFormMetadataLoader->getMetadata('form_details', $locale);
             $this->assertInstanceOf(FormMetadata::class, $formMetadata);
@@ -157,7 +160,7 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
             $sortedTypes = $types;
             \uasort(
                 $sortedTypes,
-                static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle('de'), $b->getTitle('de'))
+                static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($sortLocale), $b->getTitle($sortLocale))
             );
 
             $this->assertSame(

--- a/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
+++ b/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
@@ -51,7 +51,7 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
         $this->assertCount(28, $fields->getTypes());
         $this->assertEquals('fields', $fields->getName());
         $this->assertEquals('block', $fields->getType());
-        $this->assertEquals('text', $fields->getDefaultType());
+        $this->assertEquals('attachment', $fields->getDefaultType());
         $this->assertEqualsCanonicalizing([
             'attachment',
             'recaptcha',
@@ -110,7 +110,7 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
         $this->assertCount(28, $fields->getTypes());
         $this->assertEquals('fields', $fields->getName());
         $this->assertEquals('block', $fields->getType());
-        $this->assertEquals('text', $fields->getDefaultType());
+        $this->assertEquals('attachment', $fields->getDefaultType());
         $this->assertEqualsCanonicalizing([
             'attachment',
             'salutation',
@@ -141,6 +141,34 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
             'firstName',
             'headline',
         ], \array_keys($fields->getTypes()));
+    }
+
+    public function testGetMetadataFieldTypesAreSortedByTitle(): void
+    {
+        foreach (['de', 'en'] as $locale) {
+            $formMetadata = $this->dynamicFormMetadataLoader->getMetadata('form_details', $locale);
+            $this->assertInstanceOf(FormMetadata::class, $formMetadata);
+
+            $fields = $formMetadata->getItems()['formFields']->getItems()['fields'];
+            $this->assertInstanceOf(FieldMetadata::class, $fields);
+
+            $types = $fields->getTypes();
+
+            $sortedTypes = $types;
+            \uasort(
+                $sortedTypes,
+                static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle('de'), $b->getTitle('de'))
+            );
+
+            $this->assertSame(
+                \array_keys($sortedTypes),
+                \array_keys($types),
+                'Block types must be sorted alphabetically by their translated title.'
+            );
+
+            $this->assertSame('attachment', \array_key_first($types));
+            $this->assertSame('attachment', $fields->getDefaultType());
+        }
     }
 
     public function testGetMetadataLabelsEnglish(): void

--- a/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
+++ b/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
@@ -143,10 +143,9 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
         ], \array_keys($fields->getTypes()));
     }
 
-    public function testGetMetadataFieldTypesAreSortedByTitle(): void
+    public function testGetMetadataFieldTypesAreSortedByRequestedLocale(): void
     {
-        $enabledLocales = $this->getContainer()->getParameter('kernel.enabled_locales');
-        $sortLocale = (string) (\reset($enabledLocales) ?: 'de');
+        $orderByLocale = [];
 
         foreach (['de', 'en'] as $locale) {
             $formMetadata = $this->dynamicFormMetadataLoader->getMetadata('form_details', $locale);
@@ -157,21 +156,29 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
 
             $types = $fields->getTypes();
 
-            $sortedTypes = $types;
+            $expectedOrder = $types;
             \uasort(
-                $sortedTypes,
-                static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($sortLocale), $b->getTitle($sortLocale))
+                $expectedOrder,
+                static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($locale), $b->getTitle($locale))
             );
 
             $this->assertSame(
-                \array_keys($sortedTypes),
+                \array_keys($expectedOrder),
                 \array_keys($types),
-                'Block types must be sorted alphabetically by their translated title.'
+                \sprintf('Block types must be sorted by their "%s" title.', $locale)
             );
 
+            $this->assertSame(\array_key_first($types), $fields->getDefaultType());
             $this->assertSame('attachment', \array_key_first($types));
-            $this->assertSame('attachment', $fields->getDefaultType());
+
+            $orderByLocale[$locale] = \array_keys($types);
         }
+
+        $this->assertNotSame(
+            $orderByLocale['de'],
+            $orderByLocale['en'],
+            'German and English block type orders must differ because they are sorted by their translated title.'
+        );
     }
 
     public function testGetMetadataLabelsEnglish(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1226,11 +1226,6 @@ parameters:
 			path: Media/CollectionStrategyTree.php
 
 		-
-			message: "#^Cannot call method getName\\(\\) on Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\FormMetadata\\\\FormMetadata\\|false\\.$#"
-			count: 1
-			path: Metadata/DynamicFormMetadataLoader.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Metadata\\\\DynamicFormMetadataLoader\\:\\:getMetadata\\(\\) should return Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\MetadataInterface\\|null but returns mixed\\.$#"
 			count: 1
 			path: Metadata/DynamicFormMetadataLoader.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The block field types are now sorted alphabetically by their translated title when the form metadata is requested. The title used for sorting is resolved with the requested interface locale; when that locale is not one of the configured locales, the first configured locale is used as a fallback. As a result the default block type now resolves to the first entry alphabetically (with the configured locales this is `attachment`). The functional test suite was extended to assert the block types are ordered per locale and that the expected default type is applied.

#### Why?

The block types previously appeared in the order they were loaded, which was not predictable for editors working in the form builder. The 2.6 branch already sorted the block types alphabetically by title, but this behavior was lost in 3.0 when the title lookup became locale aware. This change restores the sorting for consistency with 2.6 and gives a stable and scannable order in the type dropdown.
