### PR TITLE
Update linting tools to be consistent with sulu/sulu 3.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
 .gitattributes export-ignore
 .gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
 .styleci.yml export-ignore
 CHANGELOG.md export-ignore
 Gruntfile.js export-ignore
 package.json export-ignore
+phpstan.neon export-ignore
+phpstan-baseline.neon export-ignore
 phpunit.xml.dist export-ignore
+rector.php export-ignore
 /Tests export-ignore

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,6 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 $config->setRiskyAllowed(true)
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -25,16 +26,28 @@ $config->setRiskyAllowed(true)
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => ['include' => ['@internal']],
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
         'ordered_imports' => true,
         'phpdoc_align' => ['align' => 'left'],
         'phpdoc_types_order' => false,
         'single_line_throw' => false,
         'single_line_comment_spacing' => false,
-        'trailing_comma_in_multiline' => false,
         'phpdoc_to_comment' => [
             'ignored_tags' => ['todo', 'var', 'see'],
         ],
+        'phpdoc_separation' => [
+            'groups' => [
+                ['Serializer\\*', 'VirtualProperty', 'Accessor', 'Type', 'Groups', 'Expose', 'Exclude', 'SerializedName', 'Inline', 'ExclusionPolicy'],
+            ],
+        ],
+        'get_class_to_class_keyword' => false, // should be enabled as soon as support for php < 8 is dropped
+        'nullable_type_declaration_for_default_null_value' => true,
+        'no_null_property_initialization' => false,
+        'fully_qualified_strict_types' => false,
+        'new_with_parentheses' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match']],
+        'no_useless_else' => false,
     ])
     ->setFinder($finder);
 

--- a/composer.json
+++ b/composer.json
@@ -43,23 +43,25 @@
         "excelwebzone/recaptcha-bundle": "^1.4.2",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^2.0",
-        "jangregor/phpstan-prophecy": "^1.0",
+        "jangregor/phpstan-prophecy": "^2.0",
         "massive/search-bundle": "^2.0",
-        "php-cs-fixer/shim": "^3.0",
+        "php-cs-fixer/shim": "^3.14",
         "phpspec/prophecy": "^1.14",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpstan/phpstan": "^1.0",
-        "phpstan/phpstan-doctrine": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/phpstan-symfony": "^1.0",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-doctrine": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^10.0 || ^11.0",
+        "rector/rector": "^2.0",
+        "spaze/phpstan-disallowed-calls": "^4.7",
         "symfony/browser-kit": "^6.4 || ^7.1",
         "symfony/dotenv": "^6.4 || ^7.1",
         "symfony/mime": "^6.4 || ^7.1",
         "symfony/monolog-bundle": "^3.1",
         "symfony/stopwatch": "^6.4 || ^7.1",
-        "symfony/var-dumper": "^6.4 || ^7.1",
-        "thecodingmachine/phpstan-strict-rules": "^1.0"
+        "symfony/var-dumper": "^6.4 || ^7.1"
     },
     "replace": {
         "sulu/sulu-form-bundle": "self.version"
@@ -95,7 +97,8 @@
             "@lint-yaml",
             "@lint-container",
             "@lint-composer",
-            "@lint-doctrine"
+            "@lint-doctrine",
+            "@lint-rector"
         ],
         "test": [
             "@phpunit"
@@ -105,8 +108,22 @@
             "Tests/Application/bin/adminconsole cache:warmup --env=dev",
             "vendor/bin/phpstan analyse"
         ],
+        "fix": [
+            "@rector",
+            "@php-cs-fix"
+        ],
         "php-cs": "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "php-cs-fix": "vendor/bin/php-cs-fixer fix",
+        "rector": [
+            "Composer\\Config::disableProcessTimeout",
+            "Tests/Application/bin/adminconsole cache:warmup --env=dev",
+            "vendor/bin/rector process"
+        ],
+        "lint-rector": [
+            "Composer\\Config::disableProcessTimeout",
+            "Tests/Application/bin/adminconsole cache:warmup --env=dev",
+            "vendor/bin/rector process --dry-run"
+        ],
         "lint-twig": "Tests/Application/bin/adminconsole lint:yaml Resources/views",
         "lint-yaml": "Tests/Application/bin/adminconsole lint:yaml Resources/config Tests/Application/config",
         "lint-composer": "@composer validate --strict",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,1057 +1,2204 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$name of method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\View\\\\ViewBuilderFactoryInterface\\:\\:createListViewBuilder\\(\\) expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\AdminBundle\\Admin\\View\\ViewBuilderFactoryInterface\:\:createListViewBuilder\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Admin/DynamicListAdmin.php
 
 		-
-			message: "#^Parameter \\#1 \\$viewName of method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\View\\\\ViewCollection\\:\\:has\\(\\) expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$tabOrder of method Sulu\\Bundle\\AdminBundle\\Admin\\View\\ListViewBuilderInterface\:\:setTabOrder\(\) expects int, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Admin/DynamicListAdmin.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			message: '#^Parameter \#1 \$viewName of method Sulu\\Bundle\\AdminBundle\\Admin\\View\\ViewCollection\:\:has\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Admin/DynamicListAdmin.php
 
 		-
-			message: "#^Cannot call method setForm\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Parameter \#2 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: Admin/DynamicListAdmin.php
+
+		-
+			message: '#^Possibly invalid array key type mixed\.$#'
+			identifier: array.invalidKey
+			count: 2
+			path: Admin/DynamicListAdmin.php
+
+		-
+			message: '#^Cannot call method setForm\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Command/FormGeneratorCommand.php
 
 		-
-			message: "#^Cannot call method setLocale\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method setLocale\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Command/FormGeneratorCommand.php
 
 		-
-			message: "#^Cannot call method setOptions\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot call method setOptions\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Command/FormGeneratorCommand.php
 
 		-
-			message: "#^Cannot call method setTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot call method setTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Command/FormGeneratorCommand.php
 
 		-
-			message: "#^Cannot call method setTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method setTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Command/FormGeneratorCommand.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\FormConfiguration\\:\\:\\$adminMailConfiguration \\(Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfigurationInterface\\) does not accept Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfigurationInterface\\|null\\.$#"
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Configuration\\FormConfiguration\:\:\$adminMailConfiguration \(Sulu\\Bundle\\FormBundle\\Configuration\\MailConfigurationInterface\) does not accept Sulu\\Bundle\\FormBundle\\Configuration\\MailConfigurationInterface\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: Configuration/FormConfiguration.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\FormConfiguration\\:\\:\\$websiteMailConfiguration \\(Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfigurationInterface\\) does not accept Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfigurationInterface\\|null\\.$#"
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Configuration\\FormConfiguration\:\:\$websiteMailConfiguration \(Sulu\\Bundle\\FormBundle\\Configuration\\MailConfigurationInterface\) does not accept Sulu\\Bundle\\FormBundle\\Configuration\\MailConfigurationInterface\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: Configuration/FormConfiguration.php
 
 		-
-			message: "#^Cannot call method getDeactivateAttachmentSave\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getDeactivateAttachmentSave\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getDeactivateCustomerMails\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getDeactivateCustomerMails\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getDeactivateNotifyMails\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getDeactivateNotifyMails\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getFromEmail\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getFromEmail\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getFromName\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getFromName\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getReceivers\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getReceivers\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getReplyTo\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getReplyTo\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getSendAttachments\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getSendAttachments\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getSubject\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getSubject\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getToEmail\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getToEmail\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Cannot call method getToName\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getToName\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$email of method Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\FormConfigurationFactory\\:\\:getEmail\\(\\) expects string\\|null, mixed given\\.$#"
+			message: '#^Parameter \#1 \$bcc of method Sulu\\Bundle\\FormBundle\\Configuration\\MailConfiguration\:\:setBcc\(\) expects array\<string\>\|string, array\<mixed\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$formId of method Sulu\\\\Bundle\\\\FormBundle\\\\Media\\\\CollectionStrategyInterface\\:\\:getCollectionId\\(\\) expects int, int\\|null given\\.$#"
+			message: '#^Parameter \#1 \$cc of method Sulu\\Bundle\\FormBundle\\Configuration\\MailConfiguration\:\:setCc\(\) expects array\<string\>\|string, array\<mixed\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$from of method Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfiguration\\:\\:setFrom\\(\\) expects array\\<string\\>\\|string, array\\<string\\>\\|null given\\.$#"
+			message: '#^Parameter \#1 \$email of method Sulu\\Bundle\\FormBundle\\Configuration\\FormConfigurationFactory\:\:getEmail\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Configuration/FormConfigurationFactory.php
+
+		-
+			message: '#^Parameter \#1 \$formId of method Sulu\\Bundle\\FormBundle\\Media\\CollectionStrategyInterface\:\:getCollectionId\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Configuration/FormConfigurationFactory.php
+
+		-
+			message: '#^Parameter \#1 \$from of method Sulu\\Bundle\\FormBundle\\Configuration\\MailConfiguration\:\:setFrom\(\) expects array\<string\>\|string, array\<string\>\|null given\.$#'
+			identifier: argument.type
 			count: 2
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$replyTo of method Sulu\\\\Bundle\\\\FormBundle\\\\Configuration\\\\MailConfiguration\\:\\:setReplyTo\\(\\) expects array\\<string\\>\\|string, array\\<string\\>\\|null given\\.$#"
+			message: '#^Parameter \#1 \$replyTo of method Sulu\\Bundle\\FormBundle\\Configuration\\MailConfiguration\:\:setReplyTo\(\) expects array\<string\>\|string, array\<string\>\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_merge expects array, array\\<string\\>\\|null given\\.$#"
+			message: '#^Parameter \#1 \$to of method Sulu\\Bundle\\FormBundle\\Configuration\\MailConfiguration\:\:setTo\(\) expects array\<string\>\|string, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Configuration/FormConfigurationFactory.php
+
+		-
+			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, array\<string\>\|null given\.$#'
+			identifier: argument.type
 			count: 3
 			path: Configuration/FormConfigurationFactory.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: Controller/DynamicController.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
 			count: 1
 			path: Controller/DynamicController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\DynamicController\\:\\:loadForm\\(\\) should return Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form but returns Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Controller\\DynamicController\:\:loadForm\(\) should return Sulu\\Bundle\\FormBundle\\Entity\\Form but returns Sulu\\Bundle\\FormBundle\\Entity\\Form\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: Controller/DynamicController.php
 
 		-
-			message: "#^Parameter \\#1 \\$dynamics of method Sulu\\\\Bundle\\\\FormBundle\\\\ListBuilder\\\\DynamicListFactory\\:\\:build\\(\\) expects array\\<Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\>, array given\\.$#"
+			message: '#^Parameter \#1 \$dynamics of method Sulu\\Bundle\\FormBundle\\ListBuilder\\DynamicListFactory\:\:build\(\) expects array\<Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\>, array\<mixed\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Controller/DynamicController.php
 
 		-
-			message: "#^Parameter \\#1 \\$id of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerInterface\\:\\:delete\\(\\) expects int, mixed given\\.$#"
+			message: '#^Parameter \#1 \$id of method Sulu\\Bundle\\MediaBundle\\Media\\Manager\\MediaManagerInterface\:\:delete\(\) expects int, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Controller/DynamicController.php
 
 		-
-			message: "#^Argument of an invalid type array\\<Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\>\\|null supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type array\<Sulu\\Bundle\\FormBundle\\Entity\\Form\>\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: Controller/FormController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\FormController\\:\\:getLimit\\(\\) should return int but returns mixed\\.$#"
+			message: '#^Binary operation "/" between mixed and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: Controller/FormController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\FormController\\:\\:getLocale\\(\\) should return string but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Controller\\FormController\:\:getLimit\(\) should return int but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Controller/FormController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\FormController\\:\\:getOffset\\(\\) should return int but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Controller\\FormController\:\:getLocale\(\) should return string but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Controller/FormController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\FormController\\:\\:getPage\\(\\) should return int but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Controller\\FormController\:\:getOffset\(\) should return int but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Controller/FormController.php
 
 		-
-			message: "#^Parameter \\#1 \\$entity of method Sulu\\\\Bundle\\\\FormBundle\\\\Controller\\\\FormController\\:\\:getApiEntity\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Controller\\FormController\:\:getPage\(\) should return int but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Controller/FormController.php
 
 		-
-			message: "#^Parameter \\#2 \\$fieldDescriptors of method Sulu\\\\Component\\\\Rest\\\\RestHelperInterface\\:\\:initializeListBuilder\\(\\) expects array\\<Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\>, array\\<Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\>\\|null given\\.$#"
+			message: '#^Parameter \#1 \$entity of method Sulu\\Bundle\\FormBundle\\Controller\\FormController\:\:getApiEntity\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\Form, Sulu\\Bundle\\FormBundle\\Entity\\Form\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Controller/FormController.php
 
 		-
-			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$fieldDescriptors of method Sulu\\Component\\Rest\\RestHelperInterface\:\:initializeListBuilder\(\) expects array\<Sulu\\Component\\Rest\\ListBuilder\\FieldDescriptorInterface\>, array\<Sulu\\Component\\Rest\\ListBuilder\\FieldDescriptorInterface\>\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Controller/FormController.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>lists" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: Controller/SelectApi/BrevoListSelectController.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>templates" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: Controller/SelectApi/BrevoMailTemplateSelectController.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: Controller/SelectApi/MailchimpListSelectController.php
+
+		-
+			message: '#^Cannot access offset ''id'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Controller/SelectApi/MailchimpListSelectController.php
+
+		-
+			message: '#^Cannot access offset ''name'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Controller/SelectApi/MailchimpListSelectController.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Controller\\SelectApi\\MailchimpListSelectController\:\:fetchAll\(\) should return array\<array\{id\: mixed, title\: string\}\> but returns list\<array\{id\: mixed, title\: mixed\}\>\.$#'
+			identifier: return.type
+			count: 1
+			path: Controller/SelectApi/MailchimpListSelectController.php
+
+		-
+			message: '#^Cannot access offset ''alias'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/CompilerPass/DynamicListBuilderCompilerPass.php
+
+		-
+			message: '#^Cannot access offset string on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
 
 		-
-			message: "#^Call to method hash\\(\\) on an unknown class Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\MessageDigestPasswordEncoder\\.$#"
+			message: '#^Parameter \#2 \$haystack of function in_array expects array, array\|bool\|float\|int\|string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: DependencyInjection/CompilerPass/RemoveTaggedServiceCollectorCompilerPass.php
+
+		-
+			message: '#^Binary operation "\." between ''sulu_form\.media…'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''collection_strategy'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''customer'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''customer_plain_text'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''default'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''delimiter'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''field'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''from'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''notify'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''notify_plain_text'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''protected'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''sender'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''strategy'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''templates'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Cannot access offset ''to'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Parameter \#2 \$value of method Symfony\\Component\\DependencyInjection\\Container\:\:setParameter\(\) expects array\|bool\|float\|int\|string\|UnitEnum\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 21
+			path: DependencyInjection/SuluFormExtension.php
+
+		-
+			message: '#^Call to method hash\(\) on an unknown class Symfony\\Component\\Security\\Core\\Encoder\\MessageDigestPasswordEncoder\.$#'
+			identifier: class.notFound
 			count: 1
 			path: Dynamic/Checksum.php
 
 		-
-			message: "#^Call to method verify\\(\\) on an unknown class Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\MessageDigestPasswordEncoder\\.$#"
+			message: '#^Call to method verify\(\) on an unknown class Symfony\\Component\\Security\\Core\\Encoder\\MessageDigestPasswordEncoder\.$#'
+			identifier: class.notFound
 			count: 1
 			path: Dynamic/Checksum.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Checksum\\:\\:\\$encoder has unknown class Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\MessageDigestPasswordEncoder as its type\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Checksum\:\:check\(\) should return bool but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Checksum.php
 
 		-
-			message: "#^Cannot call method getOption\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Checksum\:\:get\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Dynamic/Checksum.php
+
+		-
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Dynamic\\Checksum\:\:\$encoder has unknown class Symfony\\Component\\Security\\Core\\Encoder\\MessageDigestPasswordEncoder as its type\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Dynamic/Checksum.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\FormFieldTypeInterface\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/FormFieldTypeInterface.php
+
+		-
+			message: '#^Binary operation "\." between mixed and ''/\*'' results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: Dynamic/Types/AttachmentType.php
+
+		-
+			message: '#^Cannot access an offset on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: Dynamic/Types/AttachmentType.php
+
+		-
+			message: '#^Cannot access offset ''accept'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Dynamic/Types/AttachmentType.php
+
+		-
+			message: '#^Cannot access offset ''data\-max'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Dynamic/Types/AttachmentType.php
+
+		-
+			message: '#^Cannot call method getOption\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 4
 			path: Dynamic/Types/AttachmentType.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
 			count: 1
 			path: Dynamic/Types/AttachmentType.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\AttachmentType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/AttachmentType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/AttachmentType.php
+
+		-
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Dynamic/Types/BrevoType.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\BrevoType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/BrevoType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/BrevoType.php
+
+		-
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Dynamic/Types/CheckboxMultipleType.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\CheckboxMultipleType\\:\\:getDefaultOptions\\(\\) should return array\\<string\\> but returns array\\<int, string\\>\\|false\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CheckboxMultipleType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: Dynamic/Types/CheckboxMultipleType.php
 
 		-
-			message: "#^Parameter \\#1 \\$keys of function array_combine expects array\\<int\\|string\\>, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CheckboxMultipleType\:\:getChoices\(\) should return array\<string\> but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/CheckboxMultipleType.php
 
 		-
-			message: "#^Parameter \\#1 \\$translation of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\CheckboxMultipleType\\:\\:getChoiceOptions\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CheckboxMultipleType\:\:getDefaultOptions\(\) should return array\<string\> but returns list\<string\>\|false\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/CheckboxMultipleType.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\CheckboxMultipleType\\:\\:getDefaultOptions\\(\\) expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$keys of function array_combine expects array\<int\|string\>, list\<string\>\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/CheckboxMultipleType.php
 
 		-
-			message: "#^Parameter \\#2 \\$subject of function preg_split expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$translation of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CheckboxMultipleType\:\:getChoiceOptions\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation, Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/CheckboxMultipleType.php
 
 		-
-			message: "#^Parameter \\#2 \\$values of function array_combine expects array, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CheckboxMultipleType\:\:getDefaultOptions\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/CheckboxMultipleType.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Parameter \#2 \$options of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CheckboxMultipleType\:\:getChoiceOptions\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CheckboxMultipleType.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_split expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CheckboxMultipleType.php
+
+		-
+			message: '#^Parameter \#2 \$values of function array_combine expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CheckboxMultipleType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CheckboxMultipleType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CheckboxType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/CheckboxType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CheckboxType.php
+
+		-
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Dynamic/Types/CityType.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CityType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/CityType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CityType.php
+
+		-
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Dynamic/Types/CompanyType.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CompanyType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/CompanyType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CompanyType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\CountryType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/CountryType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/CountryType.php
+
+		-
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Dynamic/Types/DateType.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DateType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/DateType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DateType.php
+
+		-
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Dynamic/Types/DropdownMultiple.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\DropdownMultiple\\:\\:getDefaultOptions\\(\\) should return array\\<string\\> but returns array\\<int, string\\>\\|false\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownMultiple\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: Dynamic/Types/DropdownMultiple.php
 
 		-
-			message: "#^Parameter \\#1 \\$keys of function array_combine expects array\\<int\\|string\\>, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownMultiple\:\:getChoices\(\) should return array\<string\> but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/DropdownMultiple.php
 
 		-
-			message: "#^Parameter \\#1 \\$translation of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\DropdownMultiple\\:\\:getChoiceOptions\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownMultiple\:\:getDefaultOptions\(\) should return array\<string\> but returns list\<string\>\|false\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/DropdownMultiple.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\DropdownMultiple\\:\\:getDefaultOptions\\(\\) expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$keys of function array_combine expects array\<int\|string\>, list\<string\>\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/DropdownMultiple.php
 
 		-
-			message: "#^Parameter \\#2 \\$subject of function preg_split expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$translation of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownMultiple\:\:getChoiceOptions\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation, Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/DropdownMultiple.php
 
 		-
-			message: "#^Parameter \\#2 \\$values of function array_combine expects array, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownMultiple\:\:getDefaultOptions\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/DropdownMultiple.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\DropdownType\\:\\:getDefaultOptions\\(\\) should return array\\<string\\> but returns array\\<int, string\\>\\|false\\.$#"
+			message: '#^Parameter \#2 \$options of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownMultiple\:\:getChoiceOptions\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownMultiple.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_split expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownMultiple.php
+
+		-
+			message: '#^Parameter \#2 \$values of function array_combine expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownMultiple.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownMultiple.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: Dynamic/Types/DropdownType.php
 
 		-
-			message: "#^Parameter \\#1 \\$keys of function array_combine expects array\\<int\\|string\\>, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownType\:\:getChoices\(\) should return array\<string\> but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/DropdownType.php
 
 		-
-			message: "#^Parameter \\#1 \\$translation of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\DropdownType\\:\\:getChoiceOptions\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownType\:\:getDefaultOptions\(\) should return array\<string\> but returns list\<string\>\|false\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/DropdownType.php
 
 		-
-			message: "#^Parameter \\#2 \\$subject of function preg_split expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$keys of function array_combine expects array\<int\|string\>, list\<string\>\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/DropdownType.php
 
 		-
-			message: "#^Parameter \\#2 \\$values of function array_combine expects array, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Parameter \#1 \$translation of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownType\:\:getChoiceOptions\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation, Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/DropdownType.php
 
 		-
-			message: "#^Cannot access an offset on mixed\\.$#"
+			message: '#^Parameter \#2 \$options of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\DropdownType\:\:getChoiceOptions\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownType.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_split expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownType.php
+
+		-
+			message: '#^Parameter \#2 \$values of function array_combine expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/DropdownType.php
+
+		-
+			message: '#^Cannot access an offset on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Dynamic/Types/EmailType.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\EmailType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/EmailType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/EmailType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\FaxType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/FaxType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/FaxType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\FirstNameType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/FirstNameType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/FirstNameType.php
+
+		-
+			message: '#^Cannot access offset ''type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Dynamic/Types/FreeTextType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\FreeTextType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/FreeTextType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/FreeTextType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\FunctionType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/FunctionType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/FunctionType.php
+
+		-
+			message: '#^Cannot access offset ''type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Dynamic/Types/HeadlineType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\HeadlineType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/HeadlineType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/HeadlineType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\HiddenType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/HiddenType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/HiddenType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\LastNameType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/LastNameType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/LastNameType.php
+
+		-
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Dynamic/Types/MailchimpType.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\RadioButtonsType\\:\\:getDefaultOptions\\(\\) should return array\\<string\\> but returns array\\<int, string\\>\\|false\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\MailchimpType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/MailchimpType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/MailchimpType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\PhoneType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/PhoneType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/PhoneType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\RadioButtonsType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: Dynamic/Types/RadioButtonsType.php
 
 		-
-			message: "#^Parameter \\#1 \\$keys of function array_combine expects array\\<int\\|string\\>, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\RadioButtonsType\:\:getChoices\(\) should return array\<string\> but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/RadioButtonsType.php
 
 		-
-			message: "#^Parameter \\#1 \\$translation of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Types\\\\RadioButtonsType\\:\\:getChoiceOptions\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\RadioButtonsType\:\:getDefaultOptions\(\) should return array\<string\> but returns list\<string\>\|false\.$#'
+			identifier: return.type
 			count: 1
 			path: Dynamic/Types/RadioButtonsType.php
 
 		-
-			message: "#^Parameter \\#2 \\$subject of function preg_split expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$keys of function array_combine expects array\<int\|string\>, list\<string\>\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/RadioButtonsType.php
 
 		-
-			message: "#^Parameter \\#2 \\$values of function array_combine expects array, array\\<int, string\\>\\|false given\\.$#"
+			message: '#^Parameter \#1 \$translation of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\RadioButtonsType\:\:getChoiceOptions\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation, Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Dynamic/Types/RadioButtonsType.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getAttachment\\(\\) should return array\\<int\\>\\|null but returns mixed\\.$#"
+			message: '#^Parameter \#2 \$options of method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\RadioButtonsType\:\:getChoiceOptions\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/RadioButtonsType.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_split expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/RadioButtonsType.php
+
+		-
+			message: '#^Parameter \#2 \$values of function array_combine expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/RadioButtonsType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/RadioButtonsType.php
+
+		-
+			message: '#^Cannot access offset ''options'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Dynamic/Types/RecaptchaType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\RecaptchaType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/RecaptchaType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/RecaptchaType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\SalutationType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/SalutationType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/SalutationType.php
+
+		-
+			message: '#^Cannot access offset ''type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Dynamic/Types/SpacerType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\SpacerType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/SpacerType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/SpacerType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\StateType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/StateType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/StateType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\StreetType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/StreetType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/StreetType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\TextType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/TextType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/TextType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\TextareaType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/TextareaType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/TextareaType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\TitleType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/TitleType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/TitleType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Dynamic\\Types\\ZipType\:\:build\(\) has parameter \$builder with generic interface Symfony\\Component\\Form\\FormBuilderInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Dynamic/Types/ZipType.php
+
+		-
+			message: '#^Parameter \#3 \$options of method Symfony\\Component\\Form\\FormBuilderInterface\<mixed\>\:\:add\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Dynamic/Types/ZipType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getAttachment\(\) should return array\<int\>\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getCheckbox\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getCheckbox\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getCheckboxMultiple\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getCheckboxMultiple\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getCity\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getCity\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getCompany\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getCompany\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getCountry\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getCountry\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getData\\(\\) should return array but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getData\(\) should return array\<mixed\> but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getDate\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getDate\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getDropdown\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getDropdown\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getDropdownMultiple\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getDropdownMultiple\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getEmail\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getEmail\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getFax\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getFax\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getFirstName\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getFirstName\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getForm\\(\\) should return Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form but returns Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\|null\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getForm\(\) should return Sulu\\Bundle\\FormBundle\\Entity\\Form but returns Sulu\\Bundle\\FormBundle\\Entity\\Form\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getFunction\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getFunction\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getLastName\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getLastName\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getPhone\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getPhone\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getRadioButtons\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getRadioButtons\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getSalutation\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getSalutation\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getState\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getState\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getStreet\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getStreet\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getText\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getText\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getTextarea\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getTextarea\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getTitle\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getTitle\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:getZip\\(\\) should return string\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:getZip\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:\\$data \\(string\\|null\\) does not accept string\\|false\\.$#"
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:\$data \(string\|null\) does not accept string\|false\.$#'
+			identifier: assign.propertyType
 			count: 2
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Dynamic\\:\\:\\$webspaceKey \\(string\\) does not accept string\\|null\\.$#"
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Entity\\Dynamic\:\:\$webspaceKey \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: Entity/Dynamic.php
 
 		-
-			message: "#^Cannot call method getDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot call method getDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getFromEmail\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getFromEmail\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getFromName\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getFromName\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getMailText\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getMailText\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getOptions\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot call method getOptions\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getPlaceholder\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot call method getPlaceholder\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getShortTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot call method getShortTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getSubject\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getSubject\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getSubmitLabel\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getSubmitLabel\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getSuccessText\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getSuccessText\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot call method getTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getToEmail\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getToEmail\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Cannot call method getToName\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
+			message: '#^Cannot call method getToName\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Entity/Form.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\:\\:getOptions\\(\\) should return array but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\:\:getOptions\(\) should return array\<mixed\> but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Entity/FormFieldTranslation.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\:\\:\\$defaultValue \\(string\\|null\\) does not accept mixed\\.$#"
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\:\:\$defaultValue \(string\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: Entity/FormFieldTranslation.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\:\\:\\$options \\(string\\|null\\) does not accept string\\|false\\|null\\.$#"
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\:\:\$options \(string\|null\) does not accept string\|false\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: Entity/FormFieldTranslation.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'listId' on mixed\\.$#"
+			message: '#^Cannot access offset ''listId'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'mailTemplateId' on mixed\\.$#"
+			message: '#^Cannot access offset ''mailTemplateId'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'options' on mixed\\.$#"
+			message: '#^Cannot access offset ''options'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 3
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'redirectLink' on mixed\\.$#"
+			message: '#^Cannot access offset ''redirectLink'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			message: '#^Cannot access offset ''type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			message: '#^Cannot access offset ''value'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Parameter \\#1 \\$hrefs of method Sulu\\\\Bundle\\\\MarkupBundle\\\\Markup\\\\Link\\\\LinkProviderInterface\\:\\:preload\\(\\) expects array\\<string\\>, array\\<int, string\\|null\\> given\\.$#"
+			message: '#^Parameter \#1 \$hrefs of method Sulu\\Bundle\\MarkupBundle\\Markup\\Link\\LinkProviderInterface\:\:preload\(\) expects array\<string\>, array\<int, string\|null\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Parameter \\#1 \\$redirectLink of method Sulu\\\\Bundle\\\\FormBundle\\\\Event\\\\BrevoListSubscriber\\:\\:getUrlFromLink\\(\\) expects array\\{provider\\: string\\|null, target\\: string\\|null, anchor\\: string\\|null, query\\: string\\|null, href\\: string\\|null, title\\: string\\|null, rel\\: string\\|null, locale\\: string\\|null\\}, mixed given\\.$#"
+			message: '#^Parameter \#1 \$redirectLink of method Sulu\\Bundle\\FormBundle\\Event\\BrevoListSubscriber\:\:getUrlFromLink\(\) expects array\{provider\: string\|null, target\: string\|null, anchor\: string\|null, query\: string\|null, href\: string\|null, title\: string\|null, rel\: string\|null, locale\: string\|null\}, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Parameter \\#2 \\$locale of method Sulu\\\\Bundle\\\\MarkupBundle\\\\Markup\\\\Link\\\\LinkProviderInterface\\:\\:preload\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$locale of method Sulu\\Bundle\\MarkupBundle\\Markup\\Link\\LinkProviderInterface\:\:preload\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Event/BrevoListSubscriber.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Possibly invalid array key type mixed\.$#'
+			identifier: offsetAccess.invalidOffset
+			count: 1
+			path: Event/BrevoListSubscriber.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Event\\FormEvent\:\:__construct\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Event/FormEvent.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: Event/MailchimpListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'listId' on mixed\\.$#"
+			message: '#^Binary operation "\." between ''lists/'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: Event/MailchimpListSubscriber.php
+
+		-
+			message: '#^Cannot access offset ''listId'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Event/MailchimpListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'options' on mixed\\.$#"
+			message: '#^Cannot access offset ''options'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Event/MailchimpListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			message: '#^Cannot access offset ''type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
 			path: Event/MailchimpListSubscriber.php
 
 		-
-			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			message: '#^Cannot access offset ''value'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
 			path: Event/MailchimpListSubscriber.php
 
 		-
-			message: "#^Parameter \\#1 \\$email of method DrewM\\\\MailChimp\\\\MailChimp\\:\\:subscriberHash\\(\\) expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \$email of method DrewM\\MailChimp\\MailChimp\:\:subscriberHash\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Event/MailchimpListSubscriber.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#"
+			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Event/ProtectedMediaSubscriber.php
 
 		-
-			message: "#^In method \"Sulu\\\\Bundle\\\\FormBundle\\\\Event\\\\RequestListener\\:\\:onKernelRequest\", caught \"Exception\" must be rethrown\\. Either catch a more specific exception or add a \"throw\" clause in the \"catch\" block to propagate the exception\\. More info\\: http\\://bit\\.ly/failloud$#"
-			count: 1
-			path: Event/RequestListener.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null\\.$#"
+			message: '#^Cannot call method get\(\) on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
+			identifier: method.nonObject
 			count: 3
 			path: Form/Builder.php
 
 		-
-			message: "#^Cannot call method getAttribute\\(\\) on mixed\\.$#"
+			message: '#^Cannot call method getAttribute\(\) on mixed\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: Form/Builder.php
 
 		-
-			message: "#^Cannot call method getLocale\\(\\) on Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null\\.$#"
+			message: '#^Cannot call method getKey\(\) on mixed\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Form/Builder.php
 
 		-
-			message: "#^Parameter \\#6 \\$webspaceKey of method Sulu\\\\Bundle\\\\FormBundle\\\\Form\\\\Builder\\:\\:createForm\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Cannot call method getLocale\(\) on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Form/Builder.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\FormBundle\\\\Form\\\\Builder\\:\\:\\$cache \\(array\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\>\\) does not accept array\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\>\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:build\(\) return type with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: Form/Builder.php
 
 		-
-			message: "#^Parameter \\#1 \\$object of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:persist\\(\\) expects object, mixed given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:buildByRequest\(\) return type with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
-			path: Form/Handler.php
+			path: Form/Builder.php
 
 		-
-			message: "#^Parameter \\#1 \\$subject of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\HelperInterface\\:\\:sendMail\\(\\) expects array\\<string\\>\\|string, string\\|null given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:buildForm\(\) return type with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
-			path: Form/Handler.php
+			path: Form/Builder.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:createForm\(\) return type with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Builder.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:getWebspaceKey\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Form/Builder.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, list\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Form/Builder.php
+
+		-
+			message: '#^Parameter \#6 \$webspaceKey of method Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:createForm\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Form/Builder.php
+
+		-
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:\$cache \(array\<Symfony\\Component\\Form\\FormInterface\>\) does not accept array\<Symfony\\Component\\Form\\FormInterface\|null\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: Form/Builder.php
+
+		-
+			message: '#^Property Sulu\\Bundle\\FormBundle\\Form\\Builder\:\:\$cache with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Builder.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\BuilderInterface\:\:build\(\) return type with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/BuilderInterface.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\BuilderInterface\:\:buildByRequest\(\) return type with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/BuilderInterface.php
+
+		-
+			message: '#^Instanceof between Symfony\\Component\\HttpFoundation\\File\\UploadedFile and Symfony\\Component\\HttpFoundation\\File\\UploadedFile will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 2
 			path: Form/Handler.php
 
 		-
-			message: "#^Parameter \\#2 \\$mediaIds of method Sulu\\\\Bundle\\\\FormBundle\\\\Form\\\\Handler\\:\\:mapMediaIds\\(\\) expects array\\<int\\>, array given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:getAttachments\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: Form/Handler.php
 
 		-
-			message: "#^Parameter \\#1 \\$formEntityId of class Sulu\\\\Bundle\\\\FormBundle\\\\Exception\\\\FormNotFoundException constructor expects int, int\\|null given\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:getMediaData\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:getPlainText\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:handle\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:isSpamByHoneypot\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:save\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:sendMail\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:sendMails\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:uploadMedia\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^PHPDoc tag @var for variable \$formField contains generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 2
+			path: Form/Handler.php
+
+		-
+			message: '#^Parameter \#1 \$object of method Doctrine\\Persistence\\ObjectManager\:\:persist\(\) expects object, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Parameter \#1 \$objectOrArray of method Symfony\\Component\\PropertyAccess\\PropertyAccessor\:\:setValue\(\) expects array\<mixed\>\|object, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Parameter \#1 \$subject of method Sulu\\Bundle\\FormBundle\\Mail\\HelperInterface\:\:sendMail\(\) expects array\<string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: Form/Handler.php
+
+		-
+			message: '#^Parameter \#2 \$mediaIds of method Sulu\\Bundle\\FormBundle\\Form\\Handler\:\:mapMediaIds\(\) expects array\<int\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Form/Handler.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Form\\HandlerInterface\:\:handle\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
+			identifier: missingType.generics
+			count: 1
+			path: Form/HandlerInterface.php
+
+		-
+			message: '#^Class Sulu\\Bundle\\FormBundle\\Form\\Type\\DynamicFormType extends generic class Symfony\\Component\\Form\\AbstractType but does not specify its types\: TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: Form/Type/DynamicFormType.php
 
 		-
-			message: "#^Parameter \\#3 \\$formId of method Sulu\\\\Bundle\\\\FormBundle\\\\Dynamic\\\\Checksum\\:\\:get\\(\\) expects int, int\\|null given\\.$#"
+			message: '#^Parameter \#1 \$formEntityId of class Sulu\\Bundle\\FormBundle\\Exception\\FormNotFoundException constructor expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Form/Type/DynamicFormType.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\ListBuilder\\\\DynamicListBuilder\\:\\:toString\\(\\) should return string but returns float\\|int\\|string\\.$#"
+			message: '#^Parameter \#3 \$formId of method Sulu\\Bundle\\FormBundle\\Dynamic\\Checksum\:\:get\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Form/Type/DynamicFormType.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\ListBuilder\\DynamicListBuilder\:\:toString\(\) should return string but returns float\|int\|string\.$#'
+			identifier: return.type
 			count: 1
 			path: ListBuilder/DynamicListBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of class Sulu\\\\Bundle\\\\FormBundle\\\\Exception\\\\InvalidListBuilderValueException constructor expects string, string\\|false given\\.$#"
+			message: '#^Parameter \#1 \$value of class Sulu\\Bundle\\FormBundle\\Exception\\InvalidListBuilderValueException constructor expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: ListBuilder/DynamicListBuilder.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\ListBuilder\\\\DynamicListFactory\\:\\:build\\(\\) should return array\\<string\\> but returns array\\<int\\<0, max\\>, mixed\\>\\.$#"
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\FormBundle\\ListBuilder\\DynamicListBuilder\:\:getMediaUrl\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ListBuilder/DynamicListBuilder.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ListBuilder/DynamicListBuilder.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\ListBuilder\\DynamicListFactory\:\:build\(\) should return array\<string\> but returns list\<mixed\>\.$#'
+			identifier: return.type
 			count: 1
 			path: ListBuilder/DynamicListFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function strip_tags expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$string of function strip_tags expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: ListBuilder/DynamicListFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$address of class Symfony\\\\Component\\\\Mime\\\\Address constructor expects string, int\\|string given\\.$#"
+			message: '#^Call to function is_array\(\) with array\<int\|string, string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#1 \\$fromMail of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:logMessage\\(\\) expects array\\<int\\|string, string\\>\\|string, array\\<string\\>\\|string\\|null given\\.$#"
+			message: '#^Instanceof between SplFileInfo and SplFileInfo will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#1 \\$fromMail of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:parseToAddresses\\(\\) expects array\\<int\\|string, string\\>\\|string, array\\<string\\>\\|string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$address of class Symfony\\Component\\Mime\\Address constructor expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Mail/MailerHelper.php
+
+		-
+			message: '#^Parameter \#1 \$fromMail of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:logMessage\(\) expects array\<int\|string, string\>\|string, array\<string\>\|string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Mail/MailerHelper.php
+
+		-
+			message: '#^Parameter \#1 \$fromMail of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:parseToAddresses\(\) expects array\<int\|string, string\>\|string, array\<string\>\|string\|null given\.$#'
+			identifier: argument.type
 			count: 3
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#2 \\$subject of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:setHeaders\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			message: '#^Parameter \#2 \$subject of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:setHeaders\(\) expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#2 \\$toMail of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:logMessage\\(\\) expects array\\<int\\|string, string\\>\\|string, array\\<string\\>\\|string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$toMail of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:logMessage\(\) expects array\<int\|string, string\>\|string, array\<string\>\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#3 \\$body of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:setBody\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			message: '#^Parameter \#3 \$body of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:setBody\(\) expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#3 \\$replyTo of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:logMessage\\(\\) expects array\\<int\\|string, string\\>\\|string, array\\<string\\>\\|string\\|null given\\.$#"
+			message: '#^Parameter \#3 \$replyTo of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:logMessage\(\) expects array\<int\|string, string\>\|string, array\<string\>\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#4 \\$plainText of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:setBody\\(\\) expects string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
+			message: '#^Parameter \#4 \$plainText of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:setBody\(\) expects string\|null, array\<string\>\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#4 \\$subject of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:logMessage\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			message: '#^Parameter \#4 \$subject of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:logMessage\(\) expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#5 \\$ccMail of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:logMessage\\(\\) expects array\\<int\\|string, string\\>, array\\<string\\>\\|string given\\.$#"
+			message: '#^Parameter \#5 \$ccMail of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:logMessage\(\) expects array\<int\|string, string\>, array\<string\>\|string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#6 \\$bccMail of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:logMessage\\(\\) expects array\\<int\\|string, string\\>, array\\<string\\>\\|string given\\.$#"
+			message: '#^Parameter \#6 \$bccMail of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:logMessage\(\) expects array\<int\|string, string\>, array\<string\>\|string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Parameter \\#7 \\$plainText of method Sulu\\\\Bundle\\\\FormBundle\\\\Mail\\\\MailerHelper\\:\\:logMessage\\(\\) expects string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
+			message: '#^Parameter \#7 \$plainText of method Sulu\\Bundle\\FormBundle\\Mail\\MailerHelper\:\:logMessage\(\) expects string\|null, array\<string\>\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Mail/MailerHelper.php
 
 		-
-			message: "#^Cannot call method getId\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
+			message: '#^Cannot access offset ''email'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Cannot call method getId\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method getSendAttachments\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setChanged\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setDeactivateAttachmentSave\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setDeactivateCustomerMails\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setDeactivateNotifyMails\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setDefaultValue\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setField\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setForm\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setFromEmail\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setFromName\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setMailText\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setOptions\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setPlaceholder\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setReplyTo\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setSendAttachments\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setShortTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setSubject\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setSubmitLabel\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setSuccessText\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setTitle\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setToEmail\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Cannot call method setToName\\(\\) on Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$datetime of class DateTime constructor expects string, mixed given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$defaultLocale of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:setDefaultLocale\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$id of method Sulu\\\\Bundle\\\\FormBundle\\\\Manager\\\\FormManager\\:\\:findById\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$key of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:getField\\(\\) expects string\\|null, mixed given\\.$#"
-			count: 1
-			path: Manager/FormManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:getTranslation\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Cannot access offset ''id'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 3
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$required of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormField\\:\\:setRequired\\(\\) expects bool, mixed given\\.$#"
+			message: '#^Cannot access offset ''key'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot access offset ''type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$translation of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form\\:\\:addTranslation\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null given\\.$#"
+			message: '#^Cannot call method getId\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$translation of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormField\\:\\:addTranslation\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormFieldTranslation\\|null given\\.$#"
+			message: '#^Cannot call method getId\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormField\\:\\:setType\\(\\) expects string, mixed given\\.$#"
+			message: '#^Cannot call method getSendAttachments\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Bundle\\\\FormBundle\\\\Manager\\\\FormManager\\:\\:getUniqueKey\\(\\) expects string, mixed given\\.$#"
+			message: '#^Cannot call method setChanged\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$width of method Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormField\\:\\:setWidth\\(\\) expects string, mixed given\\.$#"
+			message: '#^Cannot call method setDeactivateAttachmentSave\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormCreatedEvent constructor expects string, string\\|null given\\.$#"
+			message: '#^Cannot call method setDeactivateCustomerMails\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormModifiedEvent constructor expects string, string\\|null given\\.$#"
+			message: '#^Cannot call method setDeactivateNotifyMails\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\FormBundle\\\\Domain\\\\Event\\\\FormTranslationAddedEvent constructor expects string, string\\|null given\\.$#"
+			message: '#^Cannot call method setDefaultValue\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#2 \\$translation of method Sulu\\\\Bundle\\\\FormBundle\\\\Manager\\\\FormManager\\:\\:updateReceivers\\(\\) expects Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation, Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\FormTranslation\\|null given\\.$#"
+			message: '#^Cannot call method setField\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#3 \\$locale of method Sulu\\\\Bundle\\\\FormBundle\\\\Manager\\\\FormManager\\:\\:updateFields\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Cannot call method setForm\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Manager/FormManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$title of method Sulu\\\\Bundle\\\\FormBundle\\\\Media\\\\CollectionStrategyTree\\:\\:createCollection\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Cannot call method setFromEmail\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setFromName\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setMailText\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setOptions\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setPlaceholder\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setReplyTo\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setSendAttachments\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setShortTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setSubject\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setSubmitLabel\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setSuccessText\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setTitle\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setToEmail\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Cannot call method setToName\(\) on Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$data of static method Sulu\\Bundle\\FormBundle\\Manager\\FormManager\:\:getValue\(\) expects array\<mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 9
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$datetime of class DateTime constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$defaultLocale of method Sulu\\Bundle\\FormBundle\\Entity\\Form\:\:setDefaultLocale\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$email of method Sulu\\Bundle\\FormBundle\\Entity\\FormTranslationReceiver\:\:setEmail\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$id of method Sulu\\Bundle\\FormBundle\\Manager\\FormManager\:\:findById\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\FormBundle\\Entity\\Form\:\:getField\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$keys of method Sulu\\Bundle\\FormBundle\\Entity\\Form\:\:getFieldsNotInArray\(\) expects array\<string\>, list given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$locale of method Sulu\\Bundle\\FormBundle\\Entity\\Form\:\:getTranslation\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\FormBundle\\Entity\\FormTranslationReceiver\:\:setName\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$required of method Sulu\\Bundle\\FormBundle\\Entity\\FormField\:\:setRequired\(\) expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$translation of method Sulu\\Bundle\\FormBundle\\Entity\\Form\:\:addTranslation\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation, Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$translation of method Sulu\\Bundle\\FormBundle\\Entity\\FormField\:\:addTranslation\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation, Sulu\\Bundle\\FormBundle\\Entity\\FormFieldTranslation\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$type of method Sulu\\Bundle\\FormBundle\\Entity\\FormField\:\:setType\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$type of method Sulu\\Bundle\\FormBundle\\Entity\\FormTranslationReceiver\:\:setType\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$type of method Sulu\\Bundle\\FormBundle\\Manager\\FormManager\:\:getUniqueKey\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$width of method Sulu\\Bundle\\FormBundle\\Entity\\FormField\:\:setWidth\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#2 \$keys of method Sulu\\Bundle\\FormBundle\\Manager\\FormManager\:\:getUniqueKey\(\) expects array\<string\>, list given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#2 \$locale of class Sulu\\Bundle\\FormBundle\\Domain\\Event\\FormCreatedEvent constructor expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#2 \$locale of class Sulu\\Bundle\\FormBundle\\Domain\\Event\\FormModifiedEvent constructor expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#2 \$locale of class Sulu\\Bundle\\FormBundle\\Domain\\Event\\FormTranslationAddedEvent constructor expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#2 \$translation of method Sulu\\Bundle\\FormBundle\\Manager\\FormManager\:\:updateReceivers\(\) expects Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation, Sulu\\Bundle\\FormBundle\\Entity\\FormTranslation\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#3 \$locale of method Sulu\\Bundle\\FormBundle\\Manager\\FormManager\:\:updateFields\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Manager/FormManager.php
+
+		-
+			message: '#^Parameter \#1 \$title of method Sulu\\Bundle\\FormBundle\\Media\\CollectionStrategyTree\:\:createCollection\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Media/CollectionStrategyTree.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Metadata\\\\DynamicFormMetadataLoader\\:\\:getMetadata\\(\\) should return Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\MetadataInterface\\|null but returns mixed\\.$#"
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Metadata\\DynamicFormMetadataLoader\:\:getMetadata\(\) should return Sulu\\Bundle\\AdminBundle\\Metadata\\MetadataInterface\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: Metadata/DynamicFormMetadataLoader.php
 
 		-
-			message: "#^Parameter \\#1 \\$data of function unserialize expects string, string\\|false given\\.$#"
+			message: '#^Parameter \#1 \$data of function unserialize expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Metadata/DynamicFormMetadataLoader.php
 
 		-
-			message: "#^Cannot call method item\\(\\) on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
+			message: '#^Parameter \#1 \$id of method Sulu\\Bundle\\FormBundle\\Manager\\FormManager\:\:findById\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Metadata/DynamicListMetadataLoader.php
+
+		-
+			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNameSpaceNode\|DOMNode\>\|false\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: Metadata/PropertiesXmlLoader.php
 
 		-
-			message: "#^Parameter \\#2 \\$fromDate of method Sulu\\\\Bundle\\\\FormBundle\\\\Repository\\\\DynamicRepository\\:\\:addDateRangeFilter\\(\\) expects string\\|null, mixed given\\.$#"
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNameSpaceNode\|DOMNode given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Metadata/PropertiesXmlLoader.php
+
+		-
+			message: '#^Parameter \#2 \$fromDate of method Sulu\\Bundle\\FormBundle\\Repository\\DynamicRepository\:\:addDateRangeFilter\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: Repository/DynamicRepository.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\FormBundle\\\\Repository\\\\FormRepository\\:\\:getValue\\(\\) should return int\\|null but returns mixed\\.$#"
+			message: '#^Parameter \#2 \$search of method Sulu\\Bundle\\FormBundle\\Repository\\DynamicRepository\:\:addSearchFilter\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Repository/DynamicRepository.php
+
+		-
+			message: '#^Parameter \#3 \$searchFields of method Sulu\\Bundle\\FormBundle\\Repository\\DynamicRepository\:\:addSearchFilter\(\) expects array\<string\>\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Repository/DynamicRepository.php
+
+		-
+			message: '#^Parameter \#3 \$toDate of method Sulu\\Bundle\\FormBundle\\Repository\\DynamicRepository\:\:addDateRangeFilter\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Repository/DynamicRepository.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\FormBundle\\Repository\\FormRepository\:\:getValue\(\) should return int\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 2
 			path: Repository/FormRepository.php
+
+		-
+			message: '#^Call to static method Webmozart\\Assert\\Assert\:\:isInstanceOf\(\) with Sulu\\Bundle\\FormBundle\\Entity\\Form and ''Sulu\\\\Bundle\\\\FormBundle\\\\Entity\\\\Form'' will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: Trash/FormTrashItemHandler.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,19 +6,27 @@ includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
-    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
+    - vendor/spaze/phpstan-disallowed-calls/extension.neon
 
 parameters:
+    phpVersion: 80200
     paths:
         - .
     level: max
+    reportUnmatchedIgnoredErrors: false
     excludePaths:
         - %currentWorkingDirectory%/vendor/*
         - %currentWorkingDirectory%/Tests/*
         - %currentWorkingDirectory%/DependencyInjection/Configuration.php
         - %currentWorkingDirectory%/Tests/prophecy-trait-bc-layer.php
+    disallowedMethodCalls:
+        -
+            method: 'Doctrine\Common\Collections\Collection::clear()'
+            message: 'use add and removeElement methods instead of clear to avoid unintended data loss if domain event listeners reflush during postFlush event'
     symfony:
-        container_xml_path: %rootDir%/../../../Tests/Application/var/cache/admin/dev/Sulu_Bundle_FormBundle_Tests_Application_KernelDevDebugContainer.xml
-        console_application_loader: Tests/phpstan/console-application.php
+        containerXmlPath: %rootDir%/../../../Tests/Application/var/cache/admin/dev/Sulu_Bundle_FormBundle_Tests_Application_KernelDevDebugContainer.xml
+        consoleApplicationLoader: Tests/phpstan/console-application.php
+        constantHassers: false
     doctrine:
         objectManagerLoader: Tests/phpstan/object-manager.php

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+
+return RectorConfig::configure()
+    ->withRootFiles()
+    ->withPaths([
+        __DIR__,
+    ])
+    ->withSkipPath(__DIR__ . '/vendor')
+    ->withSkipPath('*/var/cache')
+    ->withSkipPath('*/Tests/Application/var')
+    ->withPHPStanConfigs([
+        __DIR__ . '/phpstan.neon',
+    ])
+    ->withSymfonyContainerXml(__DIR__ . '/Tests/Application/var/cache/admin/dev/Sulu_Bundle_FormBundle_Tests_Application_KernelDevDebugContainer.xml')
+    ->withSets([
+        PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
+    ])
+    ->withRules([
+        StaticDataProviderClassMethodRector::class,
+    ])
+;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This upgrades the development linting stack to match the sulu/sulu repository. PHPStan and its extensions move to version 2.0, the php-cs-fixer configuration gains parallel execution and the newer rule set, and Rector 2.0 is introduced with a bundle adapted configuration. The phpstan-symfony configuration keys are renamed to their version 2 camelCase form, the phpstan-strict-rules dependency is replaced by phpstan-webmozart-assert and phpstan-disallowed-calls, and the PHPStan baseline is regenerated.

#### Why?

The bundle lagged a generation behind the lint tooling used in sulu/sulu 3.0, and the CI workflow already referenced Rector without the tool being installed or configured. Aligning the tools keeps static analysis and code style consistent across the Sulu ecosystem and completes the half wired Rector setup.