### PR TITLE
Fix admin form metadata falling back to German for untranslated locales

### DIFF
--- a/Metadata/DynamicFormMetadataLoader.php
+++ b/Metadata/DynamicFormMetadataLoader.php
@@ -121,8 +121,13 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
 
             $fields = $section->getItems()['fields'] ?? null;
             if ($fields instanceof FieldMetadata) {
+                $registeredTypes = $this->formFieldTypePool->all();
                 foreach ($fields->getTypes() as $typeKey => $type) {
-                    $titleKey = $this->formFieldTypePool->get($typeKey)->getConfiguration()->getTitle();
+                    if (!isset($registeredTypes[$typeKey])) {
+                        continue;
+                    }
+
+                    $titleKey = $registeredTypes[$typeKey]->getConfiguration()->getTitle();
                     $type->setTitle($this->translator->trans($titleKey, [], 'admin', $locale), $locale);
                 }
             }

--- a/Metadata/DynamicFormMetadataLoader.php
+++ b/Metadata/DynamicFormMetadataLoader.php
@@ -31,6 +31,8 @@ use Webmozart\Assert\Assert;
  */
 class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerInterface
 {
+    private const FORM_FIELDS_LABEL = 'sulu_form.form_fields';
+
     /**
      * @param array<string> $locales
      */
@@ -57,7 +59,7 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
         $formMetadata = $this->formXmlLoader->load($resource);
         $section = new SectionMetadata('formFields');
         foreach ($this->locales as $locale) {
-            $section->setLabel($this->translator->trans('sulu_form.form_fields', [], 'admin', $locale), $locale);
+            $section->setLabel($this->translator->trans(self::FORM_FIELDS_LABEL, [], 'admin', $locale), $locale);
         }
         $fields = new FieldMetadata('fields');
         $fields->setType('block');
@@ -104,15 +106,31 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
         $form = \unserialize(\file_get_contents($configCache->getPath()));
 
         if ($form instanceof FormMetadata) {
+            $this->translateForLocale($form, $locale);
             $this->sortFieldTypesByLocale($form, $locale);
         }
 
         return $form;
     }
 
+    private function translateForLocale(FormMetadata $form, string $locale): void
+    {
+        $section = $form->getItems()['formFields'] ?? null;
+        if ($section instanceof SectionMetadata) {
+            $section->setLabel($this->translator->trans(self::FORM_FIELDS_LABEL, [], 'admin', $locale), $locale);
+
+            $fields = $section->getItems()['fields'] ?? null;
+            if ($fields instanceof FieldMetadata) {
+                foreach ($fields->getTypes() as $typeKey => $type) {
+                    $titleKey = $this->formFieldTypePool->get($typeKey)->getConfiguration()->getTitle();
+                    $type->setTitle($this->translator->trans($titleKey, [], 'admin', $locale), $locale);
+                }
+            }
+        }
+    }
+
     /**
-     * Sorts the block field types alphabetically by their translated title, using the requested
-     * locale or the first configured locale when the requested one is not configured.
+     * Sorts the block field types alphabetically by their translated title in the requested locale.
      */
     private function sortFieldTypesByLocale(FormMetadata $form, string $locale): void
     {
@@ -126,12 +144,10 @@ class DynamicFormMetadataLoader implements FormMetadataLoaderInterface, CacheWar
             return;
         }
 
-        $sortLocale = \in_array($locale, $this->locales, true) ? $locale : (string) \reset($this->locales);
-
         $types = $fields->getTypes();
         \uasort(
             $types,
-            static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($sortLocale), $b->getTitle($sortLocale))
+            static fn (FormMetadata $a, FormMetadata $b): int => \strcmp($a->getTitle($locale), $b->getTitle($locale))
         );
 
         foreach (\array_keys($fields->getTypes()) as $typeKey) {

--- a/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
+++ b/Tests/Functional/Metadata/DynamicFormMetadataLoaderTest.php
@@ -25,6 +25,21 @@ class DynamicFormMetadataLoaderTest extends SuluTestCase
         $this->dynamicFormMetadataLoader = $this->getContainer()->get('sulu_form_test.dynamic_form_metadata_loader');
     }
 
+    public function testGetMetadataUntranslatedLocaleFallsBackToConfiguredFallbackLocale(): void
+    {
+        $formMetadata = $this->dynamicFormMetadataLoader->getMetadata('form_details', 'it');
+
+        $this->assertInstanceOf(FormMetadata::class, $formMetadata);
+
+        $formFields = $formMetadata->getItems()['formFields'];
+        $this->assertInstanceOf(SectionMetadata::class, $formFields);
+        $this->assertEquals('Form Fields', $formFields->getLabel('it'));
+
+        $attachment = $formFields->getItems()['fields']->getTypes()['attachment'];
+        $this->assertInstanceOf(FormMetadata::class, $attachment);
+        $this->assertEquals('Attachment', $attachment->getTitle('it'));
+    }
+
     public function testGetMetadataEnglish(): void
     {
         $formMetadata = $this->dynamicFormMetadataLoader->getMetadata('form_details', 'en');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #426 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The dynamic form metadata loader now translates the form fields section label and every field type title for the actually requested admin locale inside `getMetadata`. Previously these strings were only baked for the configured locales during cache warmup, so a requested locale that was not baked fell back to the first cached locale. The block field types are now also sorted by the requested locale. A regression test covers a requested locale that the bundle ships no translations for.

#### Why?

When the admin interface was displayed in a locale the bundle does not ship translations for, such as Italian, the form metadata fell back to the first baked locale (German) instead of the translator fallback. By translating on demand for the requested locale, the translator can apply its configured fallback locale (usually English) or a project provided translation file such as `admin.it.json`.