### PR TITLE
Keep the fo_dynamics audit foreign keys when changing the form relation

### DIFF
--- a/Tests/Functional/Migrations/Version20260702120000Test.php
+++ b/Tests/Functional/Migrations/Version20260702120000Test.php
@@ -68,6 +68,16 @@ class Version20260702120000Test extends SuluTestCase
         self::assertSame(0, $this->countDynamic('linked'));
     }
 
+    public function testUpKeepsTheAuditForeignKeys(): void
+    {
+        $this->createMigration()->up($this->introspectSchema());
+
+        $localColumns = $this->foreignKeyColumns();
+
+        self::assertContains('iduserscreator', $localColumns);
+        self::assertContains('iduserschanger', $localColumns);
+    }
+
     private function createMigration(): Version20260702120000
     {
         return new Version20260702120000($this->connection, new NullLogger());
@@ -76,6 +86,22 @@ class Version20260702120000Test extends SuluTestCase
     private function introspectSchema(): Schema
     {
         return $this->connection->createSchemaManager()->introspectSchema();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function foreignKeyColumns(): array
+    {
+        $columns = [];
+
+        foreach ($this->introspectSchema()->getTable('fo_dynamics')->getForeignKeys() as $foreignKey) {
+            foreach ($foreignKey->getLocalColumns() as $localColumn) {
+                $columns[] = \strtolower($localColumn);
+            }
+        }
+
+        return $columns;
     }
 
     private function insertForm(): int

--- a/Tests/Functional/Migrations/Version20260824120000Test.php
+++ b/Tests/Functional/Migrations/Version20260824120000Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Tests\Functional\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Psr\Log\NullLogger;
+use Sulu\Bundle\FormBundle\Migrations\Version20260824120000;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class Version20260824120000Test extends SuluTestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        self::purgeDatabase();
+
+        $this->connection = self::getEntityManager()->getConnection();
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore the canonical schema so following tests are not affected.
+        $this->createMigration()->up($this->introspectSchema());
+
+        parent::tearDown();
+    }
+
+    public function testUpRestoresTheAuditForeignKeys(): void
+    {
+        $this->createMigration()->down($this->introspectSchema());
+
+        self::assertSame(['formid'], $this->foreignKeyColumns());
+
+        $this->createMigration()->up($this->introspectSchema());
+
+        $localColumns = $this->foreignKeyColumns();
+
+        self::assertContains('iduserscreator', $localColumns);
+        self::assertContains('iduserschanger', $localColumns);
+    }
+
+    public function testUpDoesNothingWhenTheForeignKeysAreStillThere(): void
+    {
+        $before = $this->foreignKeyColumns();
+
+        $this->createMigration()->up($this->introspectSchema());
+
+        self::assertSame($before, $this->foreignKeyColumns());
+    }
+
+    private function createMigration(): Version20260824120000
+    {
+        return new Version20260824120000($this->connection, new NullLogger());
+    }
+
+    private function introspectSchema(): Schema
+    {
+        return $this->connection->createSchemaManager()->introspectSchema();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function foreignKeyColumns(): array
+    {
+        $columns = [];
+
+        foreach ($this->introspectSchema()->getTable('fo_dynamics')->getForeignKeys() as $foreignKey) {
+            foreach ($foreignKey->getLocalColumns() as $localColumn) {
+                $columns[] = \strtolower($localColumn);
+            }
+        }
+
+        \sort($columns);
+
+        return $columns;
+    }
+}

--- a/migrations/Version20260702120000.php
+++ b/migrations/Version20260702120000.php
@@ -50,7 +50,9 @@ final class Version20260702120000 extends AbstractMigration
         $newTable = clone $table;
 
         foreach ($newTable->getForeignKeys() as $foreignKey) {
-            $newTable->removeForeignKey($foreignKey->getName());
+            if (0 === \strcasecmp($foreignKey->getForeignTableName(), self::FORM_TABLE)) {
+                $newTable->removeForeignKey($foreignKey->getName());
+            }
         }
 
         $newTable->getColumn('formId')->setNotnull($notnull);

--- a/migrations/Version20260824120000.php
+++ b/migrations/Version20260824120000.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824120000 extends AbstractMigration
+{
+    private const TABLE = 'fo_dynamics';
+
+    private const USER_TABLE = 'se_users';
+
+    /**
+     * @var list<string>
+     */
+    private const AUDIT_COLUMNS = ['idUsersCreator', 'idUsersChanger'];
+
+    public function getDescription(): string
+    {
+        return 'Restore the fo_dynamics creator and changer foreign keys dropped by Version20260702120000.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable(self::USER_TABLE)) {
+            return;
+        }
+
+        $table = $schema->getTable(self::TABLE);
+        $newTable = clone $table;
+
+        foreach (self::AUDIT_COLUMNS as $column) {
+            if (!$table->hasColumn($column) || $this->hasForeignKeyOn($table, $column)) {
+                continue;
+            }
+
+            $newTable->addForeignKeyConstraint(self::USER_TABLE, [$column], ['id'], ['onDelete' => 'SET NULL']);
+        }
+
+        $this->applyDiff($table, $newTable);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable(self::TABLE);
+        $newTable = clone $table;
+
+        foreach ($newTable->getForeignKeys() as $foreignKey) {
+            if (0 === \strcasecmp($foreignKey->getForeignTableName(), self::USER_TABLE)) {
+                $newTable->removeForeignKey($foreignKey->getName());
+            }
+        }
+
+        $this->applyDiff($table, $newTable);
+    }
+
+    private function hasForeignKeyOn(Table $table, string $column): bool
+    {
+        foreach ($table->getForeignKeys() as $foreignKey) {
+            foreach ($foreignKey->getLocalColumns() as $localColumn) {
+                if (0 === \strcasecmp($localColumn, $column)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function applyDiff(Table $table, Table $newTable): void
+    {
+        $diff = $this->sm->createComparator()->compareTables($table, $newTable);
+
+        foreach ($this->platform->getAlterTableSQL($diff) as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #441
| License | MIT

#### What's in this PR?

`Version20260702120000` removed **every** foreign key of `fo_dynamics` before recreating only the one targeting `fo_forms`. The `creator` / `changer` constraints, mapped at runtime by `UserBlameSubscriber`, were therefore dropped and never restored, neither by `up()` nor by `down()`.

This PR contains three things:

- The fix: only the foreign key targeting `fo_forms` is removed now, the others are preserved.
- A follow-up migration, `Version20260824120000`, restoring the two `se_users` constraints on installations that already ran the faulty one. It goes through the Doctrine Schema API, skips constraints that are already there, and does nothing when the `se_users` table is absent.
- The tests: an assertion added to `Version20260702120000Test` checking the audit foreign keys survive, and a `Version20260824120000Test` covering both the restore and a second no-op run.

#### Why?

After the migration ran, `fo_dynamics` kept its `idUsersCreator` / `idUsersChanger` columns and their indexes but lost the constraints, so `ON DELETE SET NULL` no longer applied: deleting a user left dangling user ids behind.

The visible side effect, and how I found it, is that `doctrine:migrations:diff` kept proposing to add those two keys back on every run. On my installation `fo_dynamics` was the only auditable table out of 21 without them, while `fo_form_translations` from this same bundle had them.

#### Tests

Checked on **PostgreSQL 14 and MySQL 8** with PHP 8.4, matching the CI matrix.

- Fresh schema, original migration: only one foreign key left, bug reproduced.
- Fresh schema, fixed migration: all three foreign keys kept.
- Already broken database, follow-up migration: all three restored.
- Follow-up run a second time: no change, no error.

The new test **fails on the original code** (`Failed asserting that an array contains 'iduserscreator'`) and passes with the fix.

`php-cs-fixer` and `phpstan` are clean on the changed files.

#### Note

`se_users` is hardcoded in the follow-up migration, since that table name is fixed in the `Sulu\Bundle\SecurityBundle\Entity\User` mapping. A guard on the table's existence keeps the migration from failing on an installation that departs from it. Happy to take another approach if you prefer.
