### PR TITLE
Reset the built form cache between requests

### DIFF
--- a/Form/Builder.php
+++ b/Form/Builder.php
@@ -25,11 +25,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Builds a dynamic form.
  */
-class Builder implements BuilderInterface
+class Builder implements BuilderInterface, ResetInterface
 {
     /**
      * @var FormInterface[]
@@ -145,6 +146,23 @@ class Builder implements BuilderInterface
         return null;
     }
 
+    /**
+     * Drops the cache of already built forms.
+     *
+     * The cached forms have been through handleRequest(), so they carry the
+     * data submitted by whoever triggered the build. On a persistent runtime
+     * -- FrankenPHP worker mode, RoadRunner, Swoole -- this service outlives
+     * the request, and without this reset the next visitor would be served
+     * the previous visitor's form, already filled in.
+     */
+    public function reset(): void
+    {
+        $this->cache = [];
+    }
+
+    /**
+     * @return FormInterface<mixed>|null
+     */
     public function build(int $id, string $type, string $typeId, ?string $locale = null, string $name = 'form'): ?FormInterface
     {
         $request = $this->requestStack->getCurrentRequest();

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -121,7 +121,8 @@ return static function(ContainerConfigurator $container) {
             new Reference('sulu_form.checksum'),
             new Reference('security.csrf.token_manager'),
             '%sulu_form.csrf_protection%',
-        ]);
+        ])
+        ->tag('kernel.reset', ['method' => 'reset']);
 
     $services->set('sulu_form.form_type', DynamicFormType::class)
         ->args([

--- a/Tests/Unit/Form/BuilderTest.php
+++ b/Tests/Unit/Form/BuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\FormBundle\Tests\Unit\Form;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\FormBundle\Dynamic\Checksum;
+use Sulu\Bundle\FormBundle\Dynamic\FormFieldTypePool;
+use Sulu\Bundle\FormBundle\Form\Builder;
+use Sulu\Bundle\FormBundle\Repository\FormRepository;
+use Sulu\Bundle\FormBundle\TitleProvider\TitleProviderPoolInterface;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+class BuilderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testItIsResettable(): void
+    {
+        $this->assertInstanceOf(ResetInterface::class, $this->createBuilder());
+    }
+
+    public function testResetClearsTheFormCache(): void
+    {
+        $builder = $this->createBuilder();
+        $this->writeCache($builder, ['1__type__42__en__form' => $this->prophesize(FormInterface::class)->reveal()]);
+
+        $builder->reset();
+
+        $this->assertSame([], $this->readCache($builder));
+    }
+
+    public function testCacheIsKeptUntilResetIsCalled(): void
+    {
+        $builder = $this->createBuilder();
+        $form = $this->prophesize(FormInterface::class)->reveal();
+        $this->writeCache($builder, ['1__type__42__en__form' => $form]);
+
+        $this->assertSame(['1__type__42__en__form' => $form], $this->readCache($builder));
+    }
+
+    private function createBuilder(): Builder
+    {
+        return new Builder(
+            new RequestStack(),
+            $this->prophesize(FormFieldTypePool::class)->reveal(),
+            $this->prophesize(TitleProviderPoolInterface::class)->reveal(),
+            $this->prophesize(FormRepository::class)->reveal(),
+            $this->prophesize(FormFactory::class)->reveal(),
+            $this->prophesize(Checksum::class)->reveal(),
+            $this->prophesize(CsrfTokenManagerInterface::class)->reveal()
+        );
+    }
+
+    /**
+     * @param array<string, FormInterface<mixed>|null> $forms
+     */
+    private function writeCache(Builder $builder, array $forms): void
+    {
+        $property = new \ReflectionProperty(Builder::class, 'cache');
+        $property->setValue($builder, $forms);
+    }
+
+    /**
+     * @return array<string, FormInterface<mixed>|null>
+     */
+    private function readCache(Builder $builder): array
+    {
+        $property = new \ReflectionProperty(Builder::class, 'cache');
+        $cache = $property->getValue($builder);
+
+        return \is_array($cache) ? $cache : [];
+    }
+}

--- a/Tests/Unit/Form/BuilderTest.php
+++ b/Tests/Unit/Form/BuilderTest.php
@@ -73,6 +73,7 @@ class BuilderTest extends TestCase
     private function writeCache(Builder $builder, array $forms): void
     {
         $property = new \ReflectionProperty(Builder::class, 'cache');
+        $property->setAccessible(true);
         $property->setValue($builder, $forms);
     }
 
@@ -82,6 +83,7 @@ class BuilderTest extends TestCase
     private function readCache(Builder $builder): array
     {
         $property = new \ReflectionProperty(Builder::class, 'cache');
+        $property->setAccessible(true);
         $cache = $property->getValue($builder);
 
         return \is_array($cache) ? $cache : [];


### PR DESCRIPTION
We hit this on a production site running FrankenPHP in worker mode: a visitor opened the contact page and found someone else's name, email and message already filled in.

`Builder` caches every form it builds. The problem is that `buildForm()` runs `handleRequest()` before caching, so what gets stored is a form that already holds whatever was submitted:

```php
$form = $this->createForm(...);
$form->handleRequest($request);   // submitted data lands here
return $form;                      // and this is what gets cached
```

The cache key is `id__type__typeId__locale__name` — no session, no user. So everyone hitting the same form in the same locale gets the same entry.

On php-fpm you never see it, since the container dies with the request. On a worker runtime it stays alive and the next visitor gets the previous one's form.

The fix is a `kernel.reset` tag plus `ResetInterface`, so the container clears the cache between requests. No-op under php-fpm. The cache still does its job within a single request.

Worth noting: `sulu_form.request_listener` already has this tag. The builder just got missed.

## Repro

1. Sulu site with a dynamic form, FrankenPHP `--worker`
2. Visitor A submits
3. Visitor B opens the same page in another browser
4. B sees A's data

## Tests

`Tests/Unit/Form/BuilderTest.php`. Without the fix:

```
Error: Call to undefined method Builder::reset()
Tests: 3, Assertions: 2, Errors: 1, Failures: 1.
```

With it: `OK (3 tests, 3 assertions)`.

Targeting 3.0, happy to port elsewhere if you want it on other branches.
